### PR TITLE
harden import and export integrity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,9 @@ public/theme/dts/
 nbproject
 config/config.yaml
 config/.env
+/.env
+/.env.*
+!/.env.example
 
 # Documentor
 .phpdoc/cache

--- a/app/Command/BackupDbCommand.php
+++ b/app/Command/BackupDbCommand.php
@@ -5,6 +5,8 @@ namespace Leantime\Command;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use Leantime\Core\Configuration\Environment;
+use Leantime\Domain\DataIntegrityTools\Services\PdoDatabaseDumpService;
+use PDO;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -49,36 +51,73 @@ class BackupDbCommand extends Command
         $backupPath = APP_ROOT.'/'.$config->dbBackupPath.$backupFile;
 
         if (! is_dir(APP_ROOT.'/'.$config->dbBackupPath)) {
-            mkdir(APP_ROOT.'/'.$config->dbBackupPath);
+            mkdir(APP_ROOT.'/'.$config->dbBackupPath, 0755, true);
         }
 
+        $commandOutput = [];
+        $worked = 1;
+        if ($this->hasMysqldumpBinary()) {
+            $cmd = sprintf(
+                'mysqldump --column-statistics=0 --user=\'%s\' --password=\'%s\' --host=%s %s --port=%s --result-file=%s 2>&1',
+                $config->dbUser,
+                $config->dbPassword,
+                $config->dbHost == 'localhost' ? '127.0.0.1' : $config->dbHost,
+                $config->dbDatabase,
+                $config->dbPort,
+                $backupPath
+            );
+            exec($cmd, $commandOutput, $worked);
+        }
+
+        if ($worked === 0) {
+            chmod(APP_ROOT.'/'.$config->userFilePath, 0755);
+            $io->success('Success, database was backed up successfully');
+
+            return Command::SUCCESS;
+        }
+
+        if (! empty($commandOutput)) {
+            $io->warning('mysqldump failed, falling back to PDO export.');
+            $io->listing($commandOutput);
+        } else {
+            $io->warning('mysqldump not available, falling back to PDO export.');
+        }
+
+        try {
+            $pdo = new PDO(
+                sprintf(
+                    'mysql:host=%s;port=%s;dbname=%s;charset=utf8mb4',
+                    $config->dbHost,
+                    $config->dbPort,
+                    $config->dbDatabase
+                ),
+                $config->dbUser,
+                $config->dbPassword,
+                [
+                    PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+                    PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+                ]
+            );
+
+            app()->make(PdoDatabaseDumpService::class)->dump($pdo, $backupPath);
+            chmod(APP_ROOT.'/'.$config->userFilePath, 0755);
+            $io->success('Success, database was backed up successfully using PDO fallback');
+
+            return Command::SUCCESS;
+        } catch (\Throwable $e) {
+            $io->error('There was an issue backing up the database');
+            $io->listing([$e->getMessage()]);
+
+            return Command::FAILURE;
+        }
+    }
+
+    private function hasMysqldumpBinary(): bool
+    {
         $output = [];
-        $cmd = sprintf(
-            'mysqldump --column-statistics=0 --user=\'%s\' --password=\'%s\' --host=%s %s --port=%s --result-file=%s 2>&1',
-            $config->dbUser,
-            $config->dbPassword,
-            $config->dbHost == 'localhost' ? '127.0.0.1' : $config->dbHost,
-            $config->dbDatabase,
-            $config->dbPort,
-            $backupPath
-        );
-        exec($cmd, $output, $worked);
+        $worked = 1;
+        exec('mysqldump --version 2>&1', $output, $worked);
 
-        switch ($worked) {
-            case 0:
-                chmod(APP_ROOT.'/'.$config->userFilePath, 0755);
-                $io->success('Success, database was backedup successfully');
-
-                return Command::SUCCESS;
-
-            case 2:
-            case 1:
-                $io->error('There was an issue backing up the database');
-                $io->listing($output);
-
-                return Command::FAILURE;
-        }
-
-        return Command::FAILURE;
+        return $worked === 0;
     }
 }

--- a/app/Command/ImportSqlCommand.php
+++ b/app/Command/ImportSqlCommand.php
@@ -4,6 +4,7 @@ namespace Leantime\Command;
 
 use Aws\S3\S3Client;
 use Illuminate\Console\Command;
+use Leantime\Domain\DataIntegrityTools\Services\ImportExportSafetyService;
 use PDO;
 use RuntimeException;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -18,6 +19,8 @@ class ImportSqlCommand extends Command
                             {--file= : Path to SQL dump file}
                             {--s3-key= : S3 object key for SQL dump (e.g. bkup/u706165963_bfil_leantime.sql)}
                             {--dry-run : Parse statements only, do not execute}
+                            {--allow-destructive : Allow DROP/TRUNCATE statements to execute}
+                            {--report-file= : Write a JSON pre/post verification report to this path}
                             {--continue-on-error : Continue processing statements after an error}';
 
     protected $description = 'Import SQL dump to target MySQL without mysql client binary';
@@ -31,10 +34,15 @@ class ImportSqlCommand extends Command
         }
 
         [$handle, $sourceLabel] = $this->resolveSqlStream();
+        $sqlFile = $this->cacheStreamToTempFile($handle);
+        fclose($handle);
 
         $target = $this->resolveTargetConfig();
         $dryRun = (bool) $this->option('dry-run');
+        $allowDestructive = (bool) $this->option('allow-destructive');
         $continueOnError = (bool) $this->option('continue-on-error');
+        $reportFile = $this->resolveReportFile();
+        $safetyService = app()->make(ImportExportSafetyService::class);
 
         $this->info('Import source: '.$sourceLabel);
         $this->info(sprintf(
@@ -47,7 +55,34 @@ class ImportSqlCommand extends Command
             $this->warn('Running in dry-run mode.');
         }
 
+        $analysisHandle = fopen($sqlFile, 'rb');
+        if ($analysisHandle === false) {
+            throw new RuntimeException('Could not reopen cached SQL file for analysis.');
+        }
+        try {
+            $analysis = $safetyService->analyzeStatements($this->statementGenerator($analysisHandle));
+        } finally {
+            fclose($analysisHandle);
+        }
+        if ($analysis['destructiveCount'] > 0 && ! $allowDestructive) {
+            $this->error('Import aborted: destructive SQL detected. Re-run with --allow-destructive to override.');
+            foreach ($analysis['destructiveStatements'] as $statement) {
+                $this->line(' - '.$statement);
+            }
+            $this->writeReport($reportFile, [
+                'source' => $sourceLabel,
+                'dryRun' => $dryRun,
+                'analysis' => $analysis,
+                'aborted' => 'destructive_sql_detected',
+            ]);
+
+            @unlink($sqlFile);
+
+            return Command::FAILURE;
+        }
+
         $pdo = $this->connect($target);
+        $preflight = $safetyService->verifyDatabase($pdo);
 
         $statementCount = 0;
         $successCount = 0;
@@ -57,7 +92,12 @@ class ImportSqlCommand extends Command
             $pdo->exec('SET FOREIGN_KEY_CHECKS=0');
 
             try {
-                foreach ($this->statementGenerator($handle) as $sql) {
+                $executionHandle = fopen($sqlFile, 'rb');
+                if ($executionHandle === false) {
+                    throw new RuntimeException('Could not reopen cached SQL file for execution.');
+                }
+
+                foreach ($this->statementGenerator($executionHandle) as $sql) {
                     $statementCount++;
 
                     if ($dryRun) {
@@ -88,10 +128,25 @@ class ImportSqlCommand extends Command
                     }
                 }
             } finally {
-                fclose($handle);
+                if (isset($executionHandle) && is_resource($executionHandle)) {
+                    fclose($executionHandle);
+                }
             }
         } catch (\Throwable $e) {
             $this->error('Import aborted: '.$e->getMessage());
+            $this->writeReport($reportFile, [
+                'source' => $sourceLabel,
+                'dryRun' => $dryRun,
+                'analysis' => $analysis,
+                'preflight' => $preflight,
+                'summary' => [
+                    'statementsParsed' => $statementCount,
+                    'statementsExecuted' => $successCount,
+                    'statementErrors' => $errorCount,
+                ],
+                'error' => $e->getMessage(),
+            ]);
+            @unlink($sqlFile);
 
             return Command::FAILURE;
         } finally {
@@ -102,6 +157,21 @@ class ImportSqlCommand extends Command
             }
         }
 
+        $postflight = $safetyService->verifyDatabase($pdo);
+        $this->writeReport($reportFile, [
+            'source' => $sourceLabel,
+            'dryRun' => $dryRun,
+            'analysis' => $analysis,
+            'preflight' => $preflight,
+            'postflight' => $postflight,
+            'summary' => [
+                'statementsParsed' => $statementCount,
+                'statementsExecuted' => $successCount,
+                'statementErrors' => $errorCount,
+            ],
+        ]);
+        @unlink($sqlFile);
+
         $this->newLine();
         $this->info('SQL import summary');
         $this->line('Statements parsed: '.$statementCount);
@@ -109,6 +179,7 @@ class ImportSqlCommand extends Command
             $this->line('Statements executed: '.$successCount);
             $this->line('Statement errors: '.$errorCount);
         }
+        $this->line('Report file: '.$reportFile);
 
         return $errorCount > 0 ? Command::FAILURE : Command::SUCCESS;
     }
@@ -395,6 +466,50 @@ class ImportSqlCommand extends Command
         }
 
         return str_ends_with($trimmed, $delimiter);
+    }
+
+    private function resolveReportFile(): string
+    {
+        $explicit = trim((string) $this->option('report-file'));
+        if ($explicit !== '') {
+            return $explicit;
+        }
+
+        return APP_ROOT.'/artifacts/logs/import-report-'.date('Ymd-His').'.json';
+    }
+
+    /**
+     * @param  resource  $handle
+     */
+    private function cacheStreamToTempFile($handle): string
+    {
+        $tempFile = tempnam(sys_get_temp_dir(), 'leantime-import-');
+        if ($tempFile === false) {
+            throw new RuntimeException('Could not allocate temporary SQL cache file.');
+        }
+
+        $target = fopen($tempFile, 'wb');
+        if ($target === false) {
+            throw new RuntimeException('Could not open temporary SQL cache file for writing.');
+        }
+
+        try {
+            stream_copy_to_stream($handle, $target);
+        } finally {
+            fclose($target);
+        }
+
+        return $tempFile;
+    }
+
+    private function writeReport(string $path, array $report): void
+    {
+        $directory = dirname($path);
+        if (! is_dir($directory)) {
+            mkdir($directory, 0755, true);
+        }
+
+        file_put_contents($path, json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
     }
 }
 

--- a/app/Domain/DataIntegrityTools/Services/ImportExportSafetyService.php
+++ b/app/Domain/DataIntegrityTools/Services/ImportExportSafetyService.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Leantime\Domain\DataIntegrityTools\Services;
+
+use PDO;
+
+class ImportExportSafetyService
+{
+    /**
+     * @param  iterable<int, string>  $statements
+     * @return array{
+     *     statements:int,
+     *     createTables:int,
+     *     inserts:int,
+     *     alters:int,
+     *     updates:int,
+     *     destructiveCount:int,
+     *     destructiveStatements:array<int, string>
+     * }
+     */
+    public function analyzeStatements(iterable $statements): array
+    {
+        $report = [
+            'statements' => 0,
+            'createTables' => 0,
+            'inserts' => 0,
+            'alters' => 0,
+            'updates' => 0,
+            'destructiveCount' => 0,
+            'destructiveStatements' => [],
+        ];
+
+        foreach ($statements as $statement) {
+            $normalized = strtoupper(ltrim($statement));
+            $report['statements']++;
+
+            if (str_starts_with($normalized, 'CREATE TABLE')) {
+                $report['createTables']++;
+            } elseif (str_starts_with($normalized, 'INSERT INTO')) {
+                $report['inserts']++;
+            } elseif (str_starts_with($normalized, 'ALTER TABLE')) {
+                $report['alters']++;
+            } elseif (str_starts_with($normalized, 'UPDATE ')) {
+                $report['updates']++;
+            }
+
+            if ($this->isDestructive($normalized)) {
+                $report['destructiveCount']++;
+                if (count($report['destructiveStatements']) < 25) {
+                    $report['destructiveStatements'][] = $this->summarizeStatement($statement);
+                }
+            }
+        }
+
+        return $report;
+    }
+
+    /**
+     * @return array{
+     *     requiredTables:array<string, bool>,
+     *     rowCounts:array<string, int>,
+     *     orphanChecks:array<string, int>
+     * }
+     */
+    public function verifyDatabase(PDO $pdo): array
+    {
+        $requiredTables = [
+            'zp_projects',
+            'zp_tickets',
+            'zp_user',
+        ];
+
+        $present = [];
+        foreach ($requiredTables as $table) {
+            $present[$table] = $this->tableExists($pdo, $table);
+        }
+
+        $rowCounts = [];
+        foreach (array_keys(array_filter($present)) as $table) {
+            $rowCounts[$table] = $this->countRows($pdo, sprintf('SELECT COUNT(*) FROM `%s`', $table));
+        }
+
+        $orphanChecks = [];
+        if (($present['zp_tickets'] ?? false) && ($present['zp_projects'] ?? false)) {
+            $orphanChecks['tickets_without_project'] = $this->countRows(
+                $pdo,
+                'SELECT COUNT(*) FROM `zp_tickets` t LEFT JOIN `zp_projects` p ON p.id = t.projectId WHERE t.projectId IS NOT NULL AND p.id IS NULL'
+            );
+            $orphanChecks['milestones_without_project'] = $this->countRows(
+                $pdo,
+                "SELECT COUNT(*) FROM `zp_tickets` t LEFT JOIN `zp_projects` p ON p.id = t.projectId WHERE t.type = 'milestone' AND t.projectId IS NOT NULL AND p.id IS NULL"
+            );
+        }
+
+        if (($present['zp_timesheets'] ?? $this->tableExists($pdo, 'zp_timesheets')) && ($present['zp_tickets'] ?? false)) {
+            $orphanChecks['timesheets_without_ticket'] = $this->countRows(
+                $pdo,
+                'SELECT COUNT(*) FROM `zp_timesheets` ts LEFT JOIN `zp_tickets` t ON t.id = ts.ticketId WHERE ts.ticketId IS NOT NULL AND t.id IS NULL'
+            );
+        }
+
+        return [
+            'requiredTables' => $present,
+            'rowCounts' => $rowCounts,
+            'orphanChecks' => $orphanChecks,
+        ];
+    }
+
+    public function isDestructive(string $normalizedSql): bool
+    {
+        return preg_match('/^(DROP\s+TABLE|DROP\s+DATABASE|TRUNCATE\s+TABLE|TRUNCATE\s+)/i', $normalizedSql) === 1;
+    }
+
+    private function summarizeStatement(string $statement): string
+    {
+        $singleLine = preg_replace('/\s+/', ' ', trim($statement)) ?? trim($statement);
+
+        return mb_substr($singleLine, 0, 180);
+    }
+
+    private function tableExists(PDO $pdo, string $table): bool
+    {
+        $statement = $pdo->prepare('SHOW TABLES LIKE :table');
+        $statement->execute(['table' => $table]);
+
+        return (bool) $statement->fetchColumn();
+    }
+
+    private function countRows(PDO $pdo, string $sql): int
+    {
+        $statement = $pdo->query($sql);
+
+        return (int) $statement->fetchColumn();
+    }
+}

--- a/app/Domain/DataIntegrityTools/Services/PdoDatabaseDumpService.php
+++ b/app/Domain/DataIntegrityTools/Services/PdoDatabaseDumpService.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Leantime\Domain\DataIntegrityTools\Services;
+
+use PDO;
+use RuntimeException;
+
+class PdoDatabaseDumpService
+{
+    public function dump(PDO $pdo, string $destinationPath): void
+    {
+        $handle = fopen($destinationPath, 'wb');
+        if ($handle === false) {
+            throw new RuntimeException('Could not open backup file for writing: '.$destinationPath);
+        }
+
+        try {
+            fwrite($handle, "-- Leantime fallback SQL dump\n");
+            fwrite($handle, '-- Generated: '.date('c')."\n\n");
+            fwrite($handle, "SET FOREIGN_KEY_CHECKS=0;\n\n");
+
+            foreach ($this->getTables($pdo) as $table) {
+                fwrite($handle, sprintf("DROP TABLE IF EXISTS `%s`;\n", $table));
+                fwrite($handle, $this->getCreateTableSql($pdo, $table).";\n\n");
+
+                $this->writeInserts($pdo, $handle, $table);
+                fwrite($handle, "\n");
+            }
+
+            fwrite($handle, "SET FOREIGN_KEY_CHECKS=1;\n");
+        } finally {
+            fclose($handle);
+        }
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function getTables(PDO $pdo): array
+    {
+        $rows = $pdo->query("SHOW FULL TABLES WHERE Table_type = 'BASE TABLE'")->fetchAll(PDO::FETCH_NUM);
+
+        return array_map(static fn (array $row): string => (string) $row[0], $rows);
+    }
+
+    private function getCreateTableSql(PDO $pdo, string $table): string
+    {
+        $row = $pdo->query(sprintf('SHOW CREATE TABLE `%s`', $table))->fetch(PDO::FETCH_ASSOC);
+        if (! is_array($row)) {
+            throw new RuntimeException('Could not fetch CREATE TABLE statement for '.$table);
+        }
+
+        foreach (['Create Table', 'Create View'] as $key) {
+            if (isset($row[$key])) {
+                return (string) $row[$key];
+            }
+        }
+
+        throw new RuntimeException('Unexpected SHOW CREATE TABLE response for '.$table);
+    }
+
+    /**
+     * @param  resource  $handle
+     */
+    private function writeInserts(PDO $pdo, $handle, string $table): void
+    {
+        $statement = $pdo->query(sprintf('SELECT * FROM `%s`', $table));
+
+        while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+            $columns = array_map(
+                static fn (string $column): string => sprintf('`%s`', $column),
+                array_keys($row)
+            );
+            $values = array_map(
+                fn ($value): string => $this->quoteValue($pdo, $value),
+                array_values($row)
+            );
+
+            fwrite(
+                $handle,
+                sprintf(
+                    "INSERT INTO `%s` (%s) VALUES (%s);\n",
+                    $table,
+                    implode(', ', $columns),
+                    implode(', ', $values)
+                )
+            );
+        }
+    }
+
+    private function quoteValue(PDO $pdo, mixed $value): string
+    {
+        if ($value === null) {
+            return 'NULL';
+        }
+
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if (is_int($value) || is_float($value)) {
+            return (string) $value;
+        }
+
+        return $pdo->quote((string) $value);
+    }
+}

--- a/tests/Unit/app/Domain/DataIntegrityTools/Services/ImportExportSafetyServiceTest.php
+++ b/tests/Unit/app/Domain/DataIntegrityTools/Services/ImportExportSafetyServiceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Unit\app\Domain\DataIntegrityTools\Services;
+
+use Leantime\Domain\DataIntegrityTools\Services\ImportExportSafetyService;
+use Unit\TestCase;
+
+class ImportExportSafetyServiceTest extends TestCase
+{
+    private ImportExportSafetyService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = new ImportExportSafetyService;
+    }
+
+    public function test_analyze_statements_counts_statement_types(): void
+    {
+        $report = $this->service->analyzeStatements([
+            'CREATE TABLE `zp_projects` (`id` int);',
+            'INSERT INTO `zp_projects` (`id`) VALUES (1);',
+            'ALTER TABLE `zp_projects` ADD COLUMN `name` varchar(255);',
+            'UPDATE `zp_projects` SET `name` = \'Test\' WHERE `id` = 1;',
+        ]);
+
+        $this->assertSame(4, $report['statements']);
+        $this->assertSame(1, $report['createTables']);
+        $this->assertSame(1, $report['inserts']);
+        $this->assertSame(1, $report['alters']);
+        $this->assertSame(1, $report['updates']);
+        $this->assertSame(0, $report['destructiveCount']);
+    }
+
+    public function test_analyze_statements_flags_destructive_sql(): void
+    {
+        $report = $this->service->analyzeStatements([
+            'DROP TABLE IF EXISTS `zp_projects`;',
+            'TRUNCATE TABLE `zp_tickets`;',
+        ]);
+
+        $this->assertSame(2, $report['destructiveCount']);
+        $this->assertCount(2, $report['destructiveStatements']);
+        $this->assertStringContainsString('DROP TABLE', $report['destructiveStatements'][0]);
+        $this->assertStringContainsString('TRUNCATE TABLE', $report['destructiveStatements'][1]);
+    }
+}


### PR DESCRIPTION
## Intent summary
Harden the database export/import path so backups still work without `mysqldump`, imports are pre-scanned for destructive SQL, and every import produces a verification report for pre/post integrity checks.

## User stories / acceptance criteria
- As an operator, I can still create a DB backup when the target instance does not ship with `mysqldump`.
- As an operator, I get blocked before executing an import that contains `DROP`/`TRUNCATE` unless I explicitly opt in.
- As an operator, I get a machine-readable report showing import analysis plus pre/post integrity checks.
- As an operator, import failures surface clearly instead of silently leaving the database in an unknown state.

## Key files changed
- `.gitignore`
- `app/Command/BackupDbCommand.php`
- `app/Command/ImportSqlCommand.php`
- `app/Domain/DataIntegrityTools/Services/ImportExportSafetyService.php`
- `app/Domain/DataIntegrityTools/Services/PdoDatabaseDumpService.php`
- `tests/Unit/app/Domain/DataIntegrityTools/Services/ImportExportSafetyServiceTest.php`

## How to test
```powershell
pwsh -File scripts/bf-keryx.ps1 -Action docker-run -RepoPath "D:/projects/leantime" -DockerAction compose_up -BFMode laravel -BFServices "mysql,redis" -ForceUp -Wait -RawJson
pwsh -File scripts/bf-keryx.ps1 -Action docker-run -RepoPath "D:/projects/leantime" -DockerAction tests -BFMode laravel -BFServices "mysql,redis" -TestCommand "cd /app && vendor/bin/codecept run Unit tests/Unit/app/Domain/DataIntegrityTools/Services/ImportExportSafetyServiceTest.php" -Wait -RawJson
```

## QA checklist
- [x] Focused unit tests pass for destructive SQL analysis.
- [x] `backup:db` now has a PDO fallback path when `mysqldump` is missing.
- [x] `import:sql` aborts by default on destructive SQL and writes a report.
- [ ] Manual import run against a representative backup has been exercised in staging.
- [ ] Broader regression coverage for import/export commands has been added.

## Approval conditions
- Review the import safety tradeoff: existing full SQL dumps that contain `DROP TABLE` now require `--allow-destructive`.
- Confirm the first-pass verification set is acceptable for now (`zp_projects`, `zp_tickets`, `zp_user`, and basic orphan checks).
- Merge only after a staging import/export smoke test.
