### PR TITLE
add module-based team task csv export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,9 @@ public/theme/dts/
 nbproject
 config/config.yaml
 config/.env
+/.env
+/.env.*
+!/.env.example
 
 # Documentor
 .phpdoc/cache

--- a/app/Domain/Taskcsvexport/Controllers/Export.php
+++ b/app/Domain/Taskcsvexport/Controllers/Export.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Leantime\Domain\Taskcsvexport\Controllers;
+
+use Leantime\Core\Controller\Controller;
+use Leantime\Domain\Auth\Models\Roles;
+use Leantime\Domain\Auth\Services\Auth;
+use Leantime\Domain\Taskcsvexport\Services\TaskCsvExport as TaskCsvExportService;
+use Symfony\Component\HttpFoundation\Response;
+
+class Export extends Controller
+{
+    private TaskCsvExportService $taskCsvExportService;
+
+    public function init(TaskCsvExportService $taskCsvExportService): void
+    {
+        Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager], true);
+
+        $this->taskCsvExportService = $taskCsvExportService;
+    }
+
+    public function get(): Response
+    {
+        $csv = $this->taskCsvExportService->buildCsv($_GET);
+
+        return new Response(
+            $csv,
+            200,
+            [
+                'Content-Type' => 'text/csv; charset=utf-8',
+                'Content-Disposition' => 'attachment; filename="team-task-export-'.date('Ymd-His').'.csv"',
+                'Cache-Control' => 'no-store, no-cache, must-revalidate',
+            ]
+        );
+    }
+}

--- a/app/Domain/Taskcsvexport/Services/TaskCsvExport.php
+++ b/app/Domain/Taskcsvexport/Services/TaskCsvExport.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Leantime\Domain\Taskcsvexport\Services;
+
+use Leantime\Domain\Tickets\Services\Tickets as TicketService;
+use Leantime\Domain\Users\Services\Users as UserService;
+
+class TaskCsvExport
+{
+    public function __construct(
+        private TicketService $ticketService,
+        private UserService $userService
+    ) {}
+
+    public function buildCsv(array $requestParams): string
+    {
+        $rows = $this->buildRows($requestParams);
+        $handle = fopen('php://temp', 'r+');
+
+        fputcsv($handle, [
+            'Task',
+            'Department',
+            'Assignee',
+            'Due Date',
+            'Product / Milestone',
+            'Priority',
+        ]);
+
+        foreach ($rows as $row) {
+            fputcsv($handle, [
+                $row['task'],
+                $row['department'],
+                $row['assignee'],
+                $row['dueDate'],
+                $row['productOrMilestone'],
+                $row['priority'],
+            ]);
+        }
+
+        rewind($handle);
+        $csv = stream_get_contents($handle) ?: '';
+        fclose($handle);
+
+        return $csv;
+    }
+
+    /**
+     * @return array<int, array{task:string, department:string, assignee:string, dueDate:string, productOrMilestone:string, priority:string}>
+     */
+    public function buildRows(array $requestParams): array
+    {
+        $searchCriteria = $this->ticketService->prepareTicketSearchArray($requestParams);
+        $searchCriteria['excludeType'] = 'milestone';
+
+        $tickets = $this->ticketService->getAll($searchCriteria) ?: [];
+        $users = $this->indexUsersById($this->userService->getAll());
+        $priorityLabels = $this->ticketService->getPriorityLabels();
+
+        return array_map(function (array $ticket) use ($users, $priorityLabels): array {
+            $assignee = trim(($ticket['editorFirstname'] ?? '').' '.($ticket['editorLastname'] ?? ''));
+            $user = $users[(string) ($ticket['editorId'] ?? '')] ?? [];
+
+            return [
+                'task' => trim((string) ($ticket['headline'] ?? '')) ?: 'Untitled Task',
+                'department' => trim((string) ($user['department'] ?? '')) ?: 'No Department',
+                'assignee' => $assignee !== '' ? $assignee : 'Unassigned',
+                'dueDate' => $this->formatDueDate((string) ($ticket['dateToFinish'] ?? '')),
+                'productOrMilestone' => $this->resolveProductOrMilestone($ticket),
+                'priority' => $priorityLabels[$ticket['priority'] ?? ''] ?? 'No Priority',
+            ];
+        }, $tickets);
+    }
+
+    private function formatDueDate(string $dateToFinish): string
+    {
+        $dateToFinish = trim($dateToFinish);
+
+        if ($dateToFinish === '' || str_starts_with($dateToFinish, '0000-00-00')) {
+            return 'No Due Date';
+        }
+
+        return substr($dateToFinish, 0, 10);
+    }
+
+    private function resolveProductOrMilestone(array $ticket): string
+    {
+        $milestone = trim((string) ($ticket['milestoneHeadline'] ?? ''));
+        if ($milestone !== '') {
+            return $milestone;
+        }
+
+        $product = trim((string) ($ticket['clientName'] ?? ''));
+        if ($product !== '') {
+            return $product;
+        }
+
+        $project = trim((string) ($ticket['projectName'] ?? ''));
+        if ($project !== '') {
+            return $project;
+        }
+
+        return 'No Product or Milestone';
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $users
+     * @return array<string, array<string, mixed>>
+     */
+    private function indexUsersById(array $users): array
+    {
+        $indexed = [];
+
+        foreach ($users as $user) {
+            if (! isset($user['id'])) {
+                continue;
+            }
+
+            $indexed[(string) $user['id']] = $user;
+        }
+
+        return $indexed;
+    }
+}

--- a/app/Domain/Taskcsvexport/register.php
+++ b/app/Domain/Taskcsvexport/register.php
@@ -1,0 +1,32 @@
+<?php
+
+use Leantime\Core\Events\EventDispatcher;
+use Leantime\Domain\Auth\Models\Roles;
+use Leantime\Domain\Auth\Services\Auth;
+
+$renderExportLink = static function (): void {
+    if (! Auth::userIsAtLeast(Roles::$manager, true)) {
+        return;
+    }
+
+    $query = $_SERVER['QUERY_STRING'] ?? '';
+    $href = BASE_URL.'/taskcsvexport/export';
+
+    if ($query !== '') {
+        $href .= '?'.$query;
+    }
+
+    echo '<a class="btn btn-default" style="margin-left:8px;" href="'.htmlspecialchars($href, ENT_QUOTES, 'UTF-8').'">'.
+        '<i class="fa fa-download" aria-hidden="true"></i> Export Team CSV'.
+        '</a>';
+};
+
+EventDispatcher::add_event_listener(
+    'leantime.domain.tickets.templates.showAll.filters.afterRighthandSectionOpen',
+    $renderExportLink
+);
+
+EventDispatcher::add_event_listener(
+    'leantime.domain.tickets.templates.showList.filters.afterLefthandSectionOpen',
+    $renderExportLink
+);

--- a/tests/Unit/app/Domain/Taskcsvexport/Services/TaskCsvExportTest.php
+++ b/tests/Unit/app/Domain/Taskcsvexport/Services/TaskCsvExportTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Unit\app\Domain\Taskcsvexport\Services;
+
+use Leantime\Domain\Taskcsvexport\Services\TaskCsvExport;
+use Leantime\Domain\Tickets\Services\Tickets as TicketService;
+use Leantime\Domain\Users\Services\Users as UserService;
+use Unit\TestCase;
+
+class TaskCsvExportTest extends TestCase
+{
+    public function test_build_rows_maps_requested_columns_and_fallbacks(): void
+    {
+        $ticketService = $this->createMock(TicketService::class);
+        $userService = $this->createMock(UserService::class);
+
+        $ticketService->method('prepareTicketSearchArray')
+            ->willReturn(['currentProject' => 1, 'excludeType' => 'milestone']);
+        $ticketService->method('getAll')
+            ->willReturn([
+                [
+                    'headline' => 'Ship launch checklist',
+                    'editorId' => '7',
+                    'editorFirstname' => 'Jane',
+                    'editorLastname' => 'Doe',
+                    'dateToFinish' => '2026-03-20 04:00:00',
+                    'milestoneHeadline' => 'Launch',
+                    'clientName' => 'Morpro',
+                    'projectName' => 'PM',
+                    'priority' => 2,
+                ],
+                [
+                    'headline' => 'Backfill docs',
+                    'editorId' => '',
+                    'editorFirstname' => '',
+                    'editorLastname' => '',
+                    'dateToFinish' => '',
+                    'milestoneHeadline' => '',
+                    'clientName' => '',
+                    'projectName' => '',
+                    'priority' => '',
+                ],
+            ]);
+        $ticketService->method('getPriorityLabels')
+            ->willReturn([2 => 'High']);
+
+        $userService->method('getAll')
+            ->willReturn([
+                ['id' => 7, 'department' => 'Operations'],
+            ]);
+
+        $service = new TaskCsvExport($ticketService, $userService);
+        $rows = $service->buildRows([]);
+
+        $this->assertSame('Ship launch checklist', $rows[0]['task']);
+        $this->assertSame('Operations', $rows[0]['department']);
+        $this->assertSame('Jane Doe', $rows[0]['assignee']);
+        $this->assertSame('2026-03-20', $rows[0]['dueDate']);
+        $this->assertSame('Launch', $rows[0]['productOrMilestone']);
+        $this->assertSame('High', $rows[0]['priority']);
+
+        $this->assertSame('No Department', $rows[1]['department']);
+        $this->assertSame('Unassigned', $rows[1]['assignee']);
+        $this->assertSame('No Due Date', $rows[1]['dueDate']);
+        $this->assertSame('No Product or Milestone', $rows[1]['productOrMilestone']);
+        $this->assertSame('No Priority', $rows[1]['priority']);
+    }
+
+    public function test_build_csv_emits_header_and_rows(): void
+    {
+        $ticketService = $this->createMock(TicketService::class);
+        $userService = $this->createMock(UserService::class);
+
+        $ticketService->method('prepareTicketSearchArray')->willReturn([]);
+        $ticketService->method('getAll')->willReturn([
+            [
+                'headline' => 'Alpha',
+                'editorId' => '5',
+                'editorFirstname' => 'Sam',
+                'editorLastname' => 'Lee',
+                'dateToFinish' => '2026-03-30 12:00:00',
+                'milestoneHeadline' => '',
+                'clientName' => 'Morpro',
+                'projectName' => 'PM',
+                'priority' => 1,
+            ],
+        ]);
+        $ticketService->method('getPriorityLabels')->willReturn([1 => 'Critical']);
+        $userService->method('getAll')->willReturn([
+            ['id' => 5, 'department' => 'Delivery'],
+        ]);
+
+        $service = new TaskCsvExport($ticketService, $userService);
+        $csv = $service->buildCsv([]);
+
+        $lines = preg_split('/\r\n|\n|\r/', trim($csv)) ?: [];
+        $header = str_getcsv($lines[0]);
+        $row = str_getcsv($lines[1]);
+
+        $this->assertSame(
+            ['Task', 'Department', 'Assignee', 'Due Date', 'Product / Milestone', 'Priority'],
+            $header
+        );
+        $this->assertSame(
+            ['Alpha', 'Delivery', 'Sam Lee', '2026-03-30', 'Morpro', 'Critical'],
+            $row
+        );
+    }
+}


### PR DESCRIPTION
## Intent summary
Add a module-scoped team task CSV export that managers/admins can launch from the existing ticket views without changing core ticket controllers.

## User stories / acceptance criteria
- As a manager/admin, I can export the team task list to CSV.
- The CSV includes: Task, Department, Assignee, Due Date, Product/Milestone, Priority.
- When launched from ticket table/list views, the export reuses the active query filters.
- Empty values are explicit (`Unassigned`, `No Department`, `No Due Date`, `No Product or Milestone`, `No Priority`).
- Implementation stays module-first: new domain module + template hook injection, no ticket-controller rewrites.

## Key files changed
- `.gitignore`
- `app/Domain/Taskcsvexport/register.php`
- `app/Domain/Taskcsvexport/Controllers/Export.php`
- `app/Domain/Taskcsvexport/Services/TaskCsvExport.php`
- `tests/Unit/app/Domain/Taskcsvexport/Services/TaskCsvExportTest.php`

## How to test
```powershell
vendor\bin\codecept run Unit tests/Unit/app/Domain/Taskcsvexport/Services/TaskCsvExportTest.php
```

## QA checklist
- [x] Export link is injected through ticket template hooks, not core controller changes.
- [x] Export endpoint is restricted to owner/admin/manager roles.
- [x] CSV contains the requested columns and fallback labels.
- [x] Focused unit tests pass locally.
- [ ] Manual browser click-through on `/tickets/showAll` confirms the export link appears and downloads CSV.
- [ ] Manual filter smoke test confirms the current query string is preserved.

## Approval conditions
- Confirm the `Product / Milestone` fallback order is acceptable: `milestoneHeadline -> clientName -> projectName -> No Product or Milestone`.
- Confirm current project/task view scope is the right initial launch point for the export action.
- Merge after a browser-level export smoke test.
