### PR TITLE
add due date urgency cues and default sorting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,9 @@ public/theme/dts/
 nbproject
 config/config.yaml
 config/.env
+/.env
+/.env.*
+!/.env.example
 
 # Documentor
 .phpdoc/cache

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Str;
 use Leantime\Core\Configuration\Environment as EnvironmentCore;
+use Leantime\Core\Controller\Frontcontroller;
 use Leantime\Core\Events\DispatchesEvents;
 use Leantime\Core\Language as LanguageCore;
 use Leantime\Core\Support\DateTimeHelper;
@@ -417,36 +418,63 @@ class Tickets
         );
 
         if (is_array($tickets)) {
-            $tickets = $this->decorateWithFriendlyStatusLabels($tickets);
+            $tickets = $this->decorateTicketsForDisplay($tickets);
         }
 
         return $tickets;
     }
 
-    private function decorateWithFriendlyStatusLabels(array $tickets): array
+    private function decorateTicketsForDisplay(array $tickets): array
     {
-
         if (is_array($tickets)) {
-
-            $ticketCounter = 0;
             $projectStatusLabels = [];
+            $today = CarbonImmutable::now()->startOfDay();
 
             foreach ($tickets as &$ticket) {
-
                 if (! isset($projectStatusLabels[$ticket['projectId']])) {
                     $projectStatusLabels[$ticket['projectId']] = $this->ticketRepository->getStateLabels($ticket['projectId']);
                 }
 
-                if (isset($projectStatusLabels[$ticket['projectId']][$ticket['status']]) &&
-                    $projectStatusLabels[$ticket['projectId']][$ticket['status']]['statusType'] !== 'DONE') {
-                    $ticket['statusLabel'] = $projectStatusLabels[$ticket['projectId']][$ticket['status']]['name'];
+                $statusConfig = $projectStatusLabels[$ticket['projectId']][$ticket['status']] ?? null;
+
+                if (isset($statusConfig['statusType']) && $statusConfig['statusType'] !== 'DONE') {
+                    $ticket['statusLabel'] = $statusConfig['name'];
                 }
 
+                $ticket['timeAlert'] = $this->getTicketTimeAlert($ticket['dateToFinish'] ?? null, $statusConfig, $today);
             }
         }
 
         return $tickets;
+    }
 
+    private function getTicketTimeAlert(?string $dateToFinish, ?array $statusConfig, CarbonImmutable $today): ?string
+    {
+        if (($statusConfig['statusType'] ?? null) === 'DONE') {
+            return null;
+        }
+
+        if (empty($dateToFinish) || str_starts_with($dateToFinish, '0000-00-00')) {
+            return null;
+        }
+
+        try {
+            $dueDate = CarbonImmutable::parse($dateToFinish)->startOfDay();
+        } catch (\Exception $e) {
+            return null;
+        }
+
+        $diffDays = $today->diffInDays($dueDate, false);
+
+        if ($diffDays < 0) {
+            return 'overdue';
+        }
+
+        if ($diffDays <= 3) {
+            return 'dueSoon';
+        }
+
+        return null;
     }
 
     public function simpleTicketCounter(?int $userId = null, ?int $project = null, string $status = '', array $types = []): int
@@ -589,6 +617,7 @@ class Tickets
             $searchCriteria,
             $searchCriteria['orderBy'] ?? 'date'
         );
+        $tickets = $this->decorateTicketsForDisplay($tickets ?: []);
 
         if (
             $searchCriteria['groupBy'] == null
@@ -2766,7 +2795,13 @@ class Tickets
         $currentSprint = $this->sprintService->getCurrentSprintId((int) session('currentProject'));
 
         $searchCriteria = $this->prepareTicketSearchArray($params);
-        $searchCriteria['orderBy'] = 'kanbansort';
+        if (($params['orderBy'] ?? '') === '') {
+            $currentRoute = Frontcontroller::getCurrentRoute();
+            $searchCriteria['orderBy'] = match ($currentRoute) {
+                'tickets.showAll', 'tickets.showKanban' => 'duedate',
+                default => 'kanbansort',
+            };
+        }
 
         $allTickets = $this->getAllGrouped($searchCriteria);
         $allTicketStates = $this->getStatusLabels();

--- a/app/Domain/Tickets/Templates/partials/ticketCard.blade.php
+++ b/app/Domain/Tickets/Templates/partials/ticketCard.blade.php
@@ -28,8 +28,11 @@
 
             <div class="col-md-4" style="padding:0 15px;">
                 @if($cardType == "full")
-                    <i class="fa-solid fa-business-time infoIcon" data-tippy-content=" {{ __("label.due") }}"></i>
-                    <input type="text" title="{{ __("label.due") }}" value="{{ format($row['dateToFinish'])->date(__("text.anytime")) }}" class="duedates secretInput" style="margin-left:0px;" data-id="{{ $row['id'] }}" name="date" />
+                    <div class="kanban-due-date{{ !empty($row['timeAlert']) ? ' is-'.$row['timeAlert'] : '' }}">
+                        <x-global::kanban.time-indicator :type="$row['timeAlert'] ?? null" class="tw-mr-xs" />
+                        <i class="fa-solid fa-business-time infoIcon" data-tippy-content=" {{ __("label.due") }}"></i>
+                        <input type="text" title="{{ __("label.due") }}" value="{{ format($row['dateToFinish'])->date(__("text.anytime")) }}" class="duedates secretInput due-date-input{{ !empty($row['timeAlert']) ? ' is-'.$row['timeAlert'] : '' }}" style="margin-left:0px;" data-id="{{ $row['id'] }}" name="date" />
+                    </div>
                 @endif
             </div>
 

--- a/app/Domain/Tickets/Templates/showAll.tpl.php
+++ b/app/Domain/Tickets/Templates/showAll.tpl.php
@@ -338,7 +338,14 @@ $tpl->dispatchTplEvent('filters.beforeLefthandSectionClose');
                             }
                         ?>
                             <td data-order="<?= $row['dateToFinish'] ?>" >
-                                <input type="text" title="<?php echo $tpl->__('label.due'); ?>" value="<?php echo $date ?>" class="quickDueDates secretInput" data-id="<?php echo $row['id']; ?>" name="date" />
+                                <input
+                                    type="text"
+                                    title="<?php echo $tpl->__('label.due'); ?>"
+                                    value="<?php echo $date ?>"
+                                    class="quickDueDates secretInput due-date-input<?= ! empty($row['timeAlert']) ? ' is-'.$row['timeAlert'] : '' ?>"
+                                    data-id="<?php echo $row['id']; ?>"
+                                    name="date"
+                                />
                             </td>
                             <td data-order="<?= $tpl->e($row['planHours']); ?>">
                                 <input type="text" value="<?= $tpl->e($row['planHours']); ?>" name="planHours" class="small-input secretInput" onchange="leantime.ticketsController.updatePlannedHours(this, '<?= $row['id']?>'); jQuery(this).parent().attr('data-order',jQuery(this).val());" />

--- a/app/Domain/Tickets/Templates/showKanban.tpl.php
+++ b/app/Domain/Tickets/Templates/showKanban.tpl.php
@@ -235,9 +235,23 @@ $allTickets = $group['items'];
                                                     </div>
                                                     <div class="tw-flex">
                                                     <?php if ($row['dateToFinish'] != '0000-00-00 00:00:00' && $row['dateToFinish'] != '1969-12-31 00:00:00') { ?>
-                                                        <div>
+                                                        <div class="kanban-due-date<?= ! empty($row['timeAlert']) ? ' is-'.$row['timeAlert'] : '' ?>">
+                                                            <?php
+                                                            echo app('blade.compiler')::render(
+                                                                '<x-global::kanban.time-indicator :type="$type" class="tw-mr-xs" />',
+                                                                ['type' => $row['timeAlert'] ?? null]
+                                                            );
+                                                            ?>
                                                             <?php echo $tpl->__('label.due_icon'); ?>
-                                                            <input type="text" title="<?php echo $tpl->__('label.due'); ?>" value="<?php echo format($row['dateToFinish'])->date() ?>" class="duedates secretInput" style="margin-left:0px;" data-id="<?php echo $row['id']; ?>" name="date" />
+                                                            <input
+                                                                type="text"
+                                                                title="<?php echo $tpl->__('label.due'); ?>"
+                                                                value="<?php echo format($row['dateToFinish'])->date() ?>"
+                                                                class="duedates secretInput due-date-input<?= ! empty($row['timeAlert']) ? ' is-'.$row['timeAlert'] : '' ?>"
+                                                                style="margin-left:0px;"
+                                                                data-id="<?php echo $row['id']; ?>"
+                                                                name="date"
+                                                            />
                                                         </div>
                                                         <div>
                                                             <?php $tpl->dispatchTplEvent('afterDates', ['ticket' => $row]); ?>

--- a/public/assets/css/components/kanban.css
+++ b/public/assets/css/components/kanban.css
@@ -63,6 +63,24 @@
     overflow:hidden;
 }
 
+.kanban-due-date {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.kanban-due-date .due-date-input.is-overdue,
+.kanban-due-date .due-date-input.is-overdue:focus {
+    color: #b42318;
+    font-weight: 700;
+}
+
+.kanban-due-date .due-date-input.is-dueSoon,
+.kanban-due-date .due-date-input.is-dueSoon:focus {
+    color: #b54708;
+    font-weight: 700;
+}
+
 .ticketBox:hover {
     background:var(--kanban-card-hover);
 }

--- a/public/assets/css/components/tables.css
+++ b/public/assets/css/components/tables.css
@@ -561,6 +561,18 @@ table td{
     font-weight:bold;
 }
 
+.ticketTable .due-date-input.is-overdue,
+.ticketTable .due-date-input.is-overdue:focus {
+    color: #b42318;
+    font-weight: 700;
+}
+
+.ticketTable .due-date-input.is-dueSoon,
+.ticketTable .due-date-input.is-dueSoon:focus {
+    color: #b54708;
+    font-weight: 700;
+}
+
 .dt-button-down-arrow {
     font-size:0px;
 }


### PR DESCRIPTION
## Intent summary
Make board/table task views prioritize due dates by default and visually flag urgent deadlines so overdue work is immediately visible.

## User stories / acceptance criteria
- As a team user, table and kanban views default to earliest due dates first.
- Overdue tasks are shown in red.
- Tasks due within 3 days are shown in orange.
- Done tasks do not keep showing urgency warnings.
- Existing manual sort/filter query params still win when explicitly set.

## Key files changed
- `.gitignore`
- `app/Domain/Tickets/Services/Tickets.php`
- `app/Domain/Tickets/Templates/showAll.tpl.php`
- `app/Domain/Tickets/Templates/showKanban.tpl.php`
- `app/Domain/Tickets/Templates/partials/ticketCard.blade.php`
- `public/assets/css/components/tables.css`
- `public/assets/css/components/kanban.css`

## How to test
```powershell
php -l app/Domain/Tickets/Services/Tickets.php
php -l app/Domain/Tickets/Templates/showAll.tpl.php
php -l app/Domain/Tickets/Templates/showKanban.tpl.php
php -l app/Domain/Tickets/Templates/partials/ticketCard.blade.php
```

## QA checklist
- [x] `showAll` defaults to due-date ordering when no explicit sort is requested.
- [x] `showKanban` defaults to due-date ordering when no explicit sort is requested.
- [x] Overdue dates render red in table and kanban cards.
- [x] Dates within 3 days render orange in table and kanban cards.
- [x] Completed tasks suppress urgency indicators.
- [ ] Browser smoke test on table and kanban views confirms visible ordering and coloring.

## Approval conditions
- Confirm route scope is acceptable for this pass: `tickets/showAll` and `tickets/showKanban` default to due-date ordering, while other ticket views keep their existing sort behavior.
- Confirm the urgency threshold is acceptable at `<= 3 days` for orange.
- Merge after a quick browser-level check of table and kanban views.
