### PR TITLE
improve table view fit on standard monitors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,9 @@ public/theme/dts/
 nbproject
 config/config.yaml
 config/.env
+/.env
+/.env.*
+!/.env.example
 
 # Documentor
 .phpdoc/cache

--- a/app/Domain/Tickets/Js/ticketsController.js
+++ b/app/Domain/Tickets/Js/ticketsController.js
@@ -1634,6 +1634,9 @@ leantime.ticketsController = (function () {
                 "searching": false,
                 "stateSave": true,
                 "displayLength":100,
+                "scrollX": true,
+                "scrollCollapse": true,
+                "autoWidth": false,
                 "order": defaultOrder,
                 "columnDefs": [
                         { "visible": false, "targets": 10 },
@@ -1876,10 +1879,16 @@ leantime.ticketsController = (function () {
                 "searching": false,
                 "stateSave": true,
                 "displayLength":100,
+                "scrollX": true,
+                "scrollCollapse": true,
+                "autoWidth": false,
                 "order": defaultOrder,
                 "columnDefs": [
                     { "visible": false, "targets": 7 },
                     { "visible": false, "targets": 8 },
+                    { "visible": false, "targets": 10 },
+                    { "visible": false, "targets": 11 },
+                    { "visible": false, "targets": 12 },
                     { "target": "no-sort", "orderable": false},
                 ]
 

--- a/public/assets/css/components/tables.css
+++ b/public/assets/css/components/tables.css
@@ -561,6 +561,31 @@ table td{
     font-weight:bold;
 }
 
+.dataTables_wrapper .dt-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: flex-end;
+}
+
+.dataTables_wrapper .dataTables_scroll {
+    width: 100%;
+}
+
+.dataTables_wrapper .dataTables_scrollBody {
+    border-bottom: 1px solid var(--neutral);
+}
+
+.dataTables_wrapper .dataTables_scrollHead table.dataTable,
+.dataTables_wrapper .dataTables_scrollBody table.dataTable {
+    width: 100% !important;
+}
+
+.ticketTable.dataTable th,
+.ticketTable.dataTable td {
+    vertical-align: middle;
+}
+
 .dt-button-down-arrow {
     font-size:0px;
 }


### PR DESCRIPTION
## Intent summary
Improve the standard ticket table view fit on typical monitor widths without changing the underlying data model or table structure.

## User stories / acceptance criteria
- As a user, the ticket table can be used on a standard monitor without the layout breaking off-screen.
- As a user, I can horizontally scroll the table when needed instead of losing columns beyond the viewport.
- As a user, the least-critical width-heavy columns (planned/remaining/booked hours) start hidden by default in the main ticket table.
- As a user, the table action buttons wrap instead of widening the view further.

## Key files changed
- .gitignore
- app/Domain/Tickets/Js/ticketsController.js
- public/assets/css/components/tables.css

## How to test
Run:
  @'
  const fs = require('fs');
  new Function(fs.readFileSync('app/Domain/Tickets/Js/ticketsController.js', 'utf8'));
  console.log('ticketsController.js parse ok');
  '@ | node

## QA checklist
- [x] DataTables now enables horizontal scrolling for ticket tables.
- [x] Main ticket table hides sprint/tags plus planned/remaining/booked hours by default.
- [x] DataTables button row can wrap instead of expanding width.
- [ ] Browser smoke test confirms the ticket table fits/scrolls correctly at standard desktop widths.
- [ ] Browser smoke test confirms column visibility toggles still behave correctly.

## Approval conditions
- Confirm the main table should default-hide columns planned hours, remaining hours, and booked hours.
- Confirm horizontal scroll is acceptable as the first pass rather than a deeper table redesign.
- Merge after a quick browser-level table usability check.
