### PR TITLE
segment notification dropdown by conversations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ tests/Httprequests/http-client.private.env.json
 /AGENTS.md
 /AGENTS.behavior.md
 /harness.json
+/.env
+/.env.*
+!/.env.example

--- a/app/Domain/Menu/Composers/HeadMenu.php
+++ b/app/Domain/Menu/Composers/HeadMenu.php
@@ -9,6 +9,7 @@ use Leantime\Core\UI\Theme;
 use Leantime\Domain\Auth\Services\Auth as AuthService;
 use Leantime\Domain\Help\Services\Helper;
 use Leantime\Domain\Menu\Repositories\Menu as MenuRepo;
+use Leantime\Domain\Menu\Support\NotificationSegments;
 use Leantime\Domain\Notifications\Services\Notifications as NotificationService;
 use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 use Leantime\Domain\Users\Services\Users as UserService;
@@ -56,34 +57,13 @@ class HeadMenu extends Composer
      */
     public function with(): array
     {
-        // Fetch all notifications once, then filter for unread in PHP
-        // instead of making two separate DB queries
         $notifications = [];
         if (session()->exists('userdata')) {
             $notifications = $this->notificationService->getAllNotifications(session('userdata.id'));
         }
 
-        $nCount = is_array($notifications) ? count(array_filter($notifications, fn ($n) => ($n['read'] ?? 1) == 0)) : 0;
-        $totalNotificationCount =
-        $totalMentionCount =
-        $totalNewMentions =
-        $totalNewNotifications = 0;
-
+        $notificationSegments = NotificationSegments::partition(is_array($notifications) ? $notifications : []);
         $menuType = $this->menuRepo->getSectionMenuType(FrontcontrollerCore::getCurrentRoute(), 'project');
-
-        foreach ($notifications as $notif) {
-            if ($notif['type'] == 'mention') {
-                $totalMentionCount++;
-                if ($notif['read'] == 0) {
-                    $totalNewMentions++;
-                }
-            } else {
-                $totalNotificationCount++;
-                if ($notif['read'] == 0) {
-                    $totalNewNotifications++;
-                }
-            }
-        }
 
         $user = false;
         if (session()->exists('userdata')) {
@@ -102,13 +82,16 @@ class HeadMenu extends Composer
         }
 
         return [
-            'newNotificationCount' => $nCount,
-            'totalNotificationCount' => $totalNotificationCount,
-            'totalMentionCount' => $totalMentionCount,
-            'totalNewMentions' => $totalNewMentions,
-            'totalNewNotifications' => $totalNewNotifications,
+            'newNotificationCount' => $notificationSegments['counts']['unreadTotal'],
+            'totalNotificationCount' => $notificationSegments['counts']['totalNotificationCount'],
+            'totalMentionCount' => $notificationSegments['counts']['totalMentionCount'],
+            'totalNewMentions' => $notificationSegments['counts']['totalNewMentions'],
+            'totalNewNotifications' => $notificationSegments['counts']['totalNewNotifications'],
             'menuType' => $menuType,
             'notifications' => $notifications ?? [],
+            'commentNotifications' => $notificationSegments['comments'],
+            'activityNotifications' => $notificationSegments['activity'],
+            'mentionNotifications' => $notificationSegments['mentions'],
             'onTheClock' => session()->exists('userdata') ? $this->timesheets->isClocked(session('userdata.id')) : false,
             'activePath' => FrontcontrollerCore::getCurrentRoute(),
             'action' => FrontcontrollerCore::getActionName(),

--- a/app/Domain/Menu/Support/NotificationSegments.php
+++ b/app/Domain/Menu/Support/NotificationSegments.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Leantime\Domain\Menu\Support;
+
+class NotificationSegments
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $notifications
+     * @return array<string, mixed>
+     */
+    public static function partition(array $notifications): array
+    {
+        $segments = [
+            'mentions' => [],
+            'comments' => [],
+            'activity' => [],
+            'counts' => [
+                'unreadTotal' => 0,
+                'totalNotificationCount' => 0,
+                'totalMentionCount' => 0,
+                'totalNewMentions' => 0,
+                'totalNewNotifications' => 0,
+            ],
+        ];
+
+        foreach ($notifications as $notification) {
+            $isUnread = (int) ($notification['read'] ?? 1) === 0;
+            $isMention = ($notification['type'] ?? '') === 'mention';
+
+            if ($isUnread) {
+                $segments['counts']['unreadTotal']++;
+            }
+
+            if ($isMention) {
+                $segments['mentions'][] = $notification;
+                $segments['counts']['totalMentionCount']++;
+
+                if ($isUnread) {
+                    $segments['counts']['totalNewMentions']++;
+                }
+
+                continue;
+            }
+
+            $segments['counts']['totalNotificationCount']++;
+
+            if ($isUnread) {
+                $segments['counts']['totalNewNotifications']++;
+            }
+
+            if (($notification['module'] ?? '') === 'comments') {
+                $segments['comments'][] = $notification;
+            } else {
+                $segments['activity'][] = $notification;
+            }
+        }
+
+        return $segments;
+    }
+}

--- a/app/Domain/Menu/Templates/headMenu.blade.php
+++ b/app/Domain/Menu/Templates/headMenu.blade.php
@@ -92,30 +92,26 @@
                         <p style='padding: 10px'>{{ __('text.no_notifications') }}</p>
                     @endif
 
-                    @foreach ($notifications as $notif)
-                        @if ($notif['type'] == 'mention')
-                            @continue
+                    @if (count($commentNotifications) > 0)
+                        <li class="notificationSection">{{ __('label.notification_category_comments') }}</li>
+                        @foreach ($commentNotifications as $notif)
+                            @include('menu::partials.notificationListItem', ['notif' => $notif])
+                        @endforeach
+                    @endif
+
+                    @if (count($commentNotifications) > 0 && count($activityNotifications) > 0)
+                        <li class="notificationSectionDivider" aria-hidden="true"></li>
+                    @endif
+
+                    @if (count($activityNotifications) > 0)
+                        @if (count($commentNotifications) > 0)
+                            <li class="notificationSection">{{ __('label.notifications_all_activity') }}</li>
                         @endif
 
-                        <li
-                            @if ($notif['read'] == 0)
-                                class='new'
-                            @endif
-                            data-url="{{ $notif['url'] }}"
-                            data-id="{{ $notif['id'] }}"
-                        >
-                            <a href="{{ $notif['url'] }}">
-                                <span class="notificationProfileImage">
-                                    <img src="{{ BASE_URL }}/api/users?profileImage={{ $notif['authorId'] }}"/>
-                                </span>
-                                <span class="notificationDate">
-                                    {{ format($notif['datetime'])->date() }}
-                                    {{ format($notif['datetime'])->time() }}
-                                </span>
-                                <span class="notificationTitle">{!! strip_tags($tpl->convertRelativePaths($notif['message'])) !!}</span>
-                            </a>
-                        </li>
-                    @endforeach
+                        @foreach ($activityNotifications as $notif)
+                            @include('menu::partials.notificationListItem', ['notif' => $notif])
+                        @endforeach
+                    @endif
                 </ul>
 
                 <ul id='mentionsList' style='display:none;' class='notificationViewLists'>
@@ -123,29 +119,8 @@
                         <p style="padding: 10px">{{ __('text.no_notifications') }}</p>
                     @endif
 
-                    @foreach ($notifications as $notif)
-                        @if ($notif['type'] != 'mention')
-                            @continue
-                        @endif
-
-                        <li
-                            @if ($notif['read'] == 0)
-                                class='new'
-                            @endif
-                            data-url="{{ $notif['url'] }}"
-                            data-id="{{ $notif['id'] }}"
-                        >
-                            <a href="{{ $notif['url'] }}">
-                                <span class="notificationProfileImage">
-                                    <img src="{{ BASE_URL }}/api/users?profileImage={{ $notif['authorId'] }}"/>
-                                </span>
-                                <span class="notificationDate">
-                                    {{ format($notif['datetime'])->date() }}
-                                    {{ format($notif['datetime'])->time() }}
-                                </span>
-                                <span class="notificationTitle">{!! strip_tags($tpl->convertRelativePaths($notif['message'])) !!}</span>
-                            </a>
-                        </li>
+                    @foreach ($mentionNotifications as $notif)
+                        @include('menu::partials.notificationListItem', ['notif' => $notif])
                     @endforeach
                 </ul>
 

--- a/app/Domain/Menu/Templates/partials/notificationListItem.blade.php
+++ b/app/Domain/Menu/Templates/partials/notificationListItem.blade.php
@@ -1,0 +1,18 @@
+<li
+    @if (($notif['read'] ?? 1) == 0)
+        class='new'
+    @endif
+    data-url="{{ $notif['url'] }}"
+    data-id="{{ $notif['id'] }}"
+>
+    <a href="{{ $notif['url'] }}">
+        <span class="notificationProfileImage">
+            <img src="{{ BASE_URL }}/api/users?profileImage={{ $notif['authorId'] }}"/>
+        </span>
+        <span class="notificationDate">
+            {{ format($notif['datetime'])->date() }}
+            {{ format($notif['datetime'])->time() }}
+        </span>
+        <span class="notificationTitle">{!! strip_tags($tpl->convertRelativePaths($notif['message'])) !!}</span>
+    </a>
+</li>

--- a/public/assets/css/components/nav.css
+++ b/public/assets/css/components/nav.css
@@ -1017,6 +1017,30 @@ a.barmenu:hover {
     color:var(--primary-font-color);
 }
 
+.notificationDropdown .dropdown-menu li.notificationSection {
+    padding: 12px 10px 6px;
+    margin: 0;
+    font-size: var(--font-size-xs);
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--primary-font-color);
+    cursor: default;
+}
+
+.notificationDropdown .dropdown-menu li.notificationSection:hover,
+.notificationDropdown .dropdown-menu li.notificationSectionDivider:hover {
+    background: transparent;
+    cursor: default;
+}
+
+.notificationDropdown .dropdown-menu li.notificationSectionDivider {
+    padding: 0;
+    margin: 6px 10px;
+    min-height: 0;
+    border-top: 1px solid var(--main-border-color);
+}
+
 .notificationDropdown .notifcationTabs.active{
     font-weight:bold;
 

--- a/tests/Unit/app/Domain/Menu/Support/NotificationSegmentsTest.php
+++ b/tests/Unit/app/Domain/Menu/Support/NotificationSegmentsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Unit\app\Domain\Menu\Support;
+
+use Leantime\Domain\Menu\Support\NotificationSegments;
+use PHPUnit\Framework\TestCase;
+
+class NotificationSegmentsTest extends TestCase
+{
+    public function test_partition_splits_mentions_comments_and_activity(): void
+    {
+        $notifications = [
+            ['id' => 1, 'type' => 'mention', 'module' => 'comments', 'read' => 0],
+            ['id' => 2, 'type' => 'notification', 'module' => 'comments', 'read' => 0],
+            ['id' => 3, 'type' => 'notification', 'module' => 'tickets', 'read' => 1],
+            ['id' => 4, 'type' => 'notification', 'module' => 'ideas', 'read' => 0],
+        ];
+
+        $segments = NotificationSegments::partition($notifications);
+
+        $this->assertSame([1], array_column($segments['mentions'], 'id'));
+        $this->assertSame([2], array_column($segments['comments'], 'id'));
+        $this->assertSame([3, 4], array_column($segments['activity'], 'id'));
+
+        $this->assertSame(3, $segments['counts']['unreadTotal']);
+        $this->assertSame(1, $segments['counts']['totalMentionCount']);
+        $this->assertSame(1, $segments['counts']['totalNewMentions']);
+        $this->assertSame(3, $segments['counts']['totalNotificationCount']);
+        $this->assertSame(2, $segments['counts']['totalNewNotifications']);
+    }
+
+    public function test_partition_handles_missing_fields_defensively(): void
+    {
+        $segments = NotificationSegments::partition([
+            ['id' => 5],
+        ]);
+
+        $this->assertSame([], $segments['mentions']);
+        $this->assertSame([], $segments['comments']);
+        $this->assertSame([5], array_column($segments['activity'], 'id'));
+        $this->assertSame(0, $segments['counts']['unreadTotal']);
+        $this->assertSame(1, $segments['counts']['totalNotificationCount']);
+    }
+}


### PR DESCRIPTION
## Intent summary
Prioritize comment-thread notifications inside the bell dropdown so conversation updates stay visible above general project activity.

## User stories / acceptance criteria
- As a user, I can see comment-driven notifications grouped at the top of the notifications tab.
- As a user, I can still see the remaining non-mention notifications below a visual divider.
- As a user, mentions remain in their own tab and unread counters still reflect the full bell dropdown.
- As a maintainer, the change stays upstream-safe with no schema changes.

## Key files changed
- `.gitignore`
- `app/Domain/Menu/Composers/HeadMenu.php`
- `app/Domain/Menu/Support/NotificationSegments.php`
- `app/Domain/Menu/Templates/headMenu.blade.php`
- `app/Domain/Menu/Templates/partials/notificationListItem.blade.php`
- `public/assets/css/components/nav.css`
- `tests/Unit/app/Domain/Menu/Support/NotificationSegmentsTest.php`

## How to test
- `php -l app/Domain/Menu/Composers/HeadMenu.php`
- `php -l app/Domain/Menu/Support/NotificationSegments.php`
- `php -l app/Domain/Menu/Templates/partials/notificationListItem.blade.php`
- `php -l app/Domain/Menu/Templates/headMenu.blade.php`
- `vendor\bin\codecept run Unit tests/Unit/app/Domain/Menu/Support/NotificationSegmentsTest.php`
- In the UI, open the bell dropdown and confirm comment notifications render first, then a divider, then the remaining activity notifications.

## QA checklist
- [ ] Comment notifications are shown before other non-mention notifications.
- [ ] Mentions still appear only in the Mentions tab.
- [ ] Unread counts still match the full notification set.
- [ ] Dropdown styling remains readable on desktop.

## Approval conditions
- Focused unit test passes.
- Basic bell-dropdown smoke check passes in browser.
- No regression to mention tab behavior.
