### PR TITLE
improve subtask sequencing and parent progress

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ tests/Httprequests/http-client.private.env.json
 /AGENTS.md
 /AGENTS.behavior.md
 /harness.json
+/.env
+/.env.*
+!/.env.example

--- a/app/Domain/Tickets/Hxcontrollers/Subtasks.php
+++ b/app/Domain/Tickets/Hxcontrollers/Subtasks.php
@@ -41,6 +41,7 @@ class Subtasks extends HtmxController
 
         $this->tpl->assign('ticket', $ticket);
         $this->tpl->assign('ticketSubtasks', $ticketSubtasks);
+        $this->tpl->assign('subtaskSummary', $this->ticketService->getSubtaskSummary($ticket->id));
         $this->tpl->assign('statusLabels', $statusLabels);
         $this->tpl->assign('efforts', $efforts);
     }
@@ -62,6 +63,7 @@ class Subtasks extends HtmxController
 
         $this->tpl->assign('ticket', $ticket);
         $this->tpl->assign('ticketSubtasks', $ticketSubtasks);
+        $this->tpl->assign('subtaskSummary', $this->ticketService->getSubtaskSummary((int) $id));
         $this->tpl->assign('statusLabels', $statusLabels);
         $this->tpl->assign('efforts', $efforts);
 
@@ -80,6 +82,8 @@ class Subtasks extends HtmxController
             $this->tpl->setNotification($this->language->__('notifications.subtask_delete_error'), 'error');
         }
 
+        $this->ticketService->syncParentCompletionFromSubtasks((int) $parentId);
+
         $ticket = $this->ticketService->getTicket($parentId);
         $ticketSubtasks = $this->ticketService->getAllSubtasks($parentId);
         $statusLabels = $this->ticketService->getStatusLabels(session('currentProject'));
@@ -87,6 +91,7 @@ class Subtasks extends HtmxController
 
         $this->tpl->assign('ticket', $ticket);
         $this->tpl->assign('ticketSubtasks', $ticketSubtasks);
+        $this->tpl->assign('subtaskSummary', $this->ticketService->getSubtaskSummary((int) $parentId));
         $this->tpl->assign('statusLabels', $statusLabels);
         $this->tpl->assign('efforts', $efforts);
     }

--- a/app/Domain/Tickets/Js/ticketsController.js
+++ b/app/Domain/Tickets/Js/ticketsController.js
@@ -661,6 +661,16 @@ leantime.ticketsController = (function () {
         jQuery('[data-toggle="tooltip"]').tooltip();
     };
 
+    var triggerSubtaskRefreshIfNeeded = function (element) {
+        if (!window.htmx) {
+            return;
+        }
+
+        if (jQuery(element).closest("#ticketSubtasks").length > 0) {
+            htmx.trigger(document.body, "subtasksUpdated");
+        }
+    };
+
     var initEffortDropdown = function () {
 
         var storyPointLabels = {
@@ -674,6 +684,7 @@ leantime.ticketsController = (function () {
         };
 
         jQuery(".effortDropdown .dropdown-menu a").unbind().on("click", function () {
+            var sourceElement = this;
 
             var dataValue = jQuery(this).attr("data-value").split("_");
 
@@ -695,6 +706,7 @@ leantime.ticketsController = (function () {
                     function () {
                         jQuery("#effortDropdownMenuLink" + ticketId + " span.text").text(storyPointLabels[effortId]);
                         jQuery.growl({message: leantime.i18n.__("short_notifications.effort_updated"), style: "success"});
+                        triggerSubtaskRefreshIfNeeded(sourceElement);
 
                         // Move card to correct swimlane if grouped by effort
                         if (leantime.kanbanGroupBy === 'storypoints') {
@@ -807,6 +819,7 @@ leantime.ticketsController = (function () {
     var initStatusDropdown = function () {
 
         jQuery(".statusDropdown .dropdown-menu a").unbind().on("click", function () {
+                var sourceElement = this;
 
                 var dataValue = jQuery(this).attr("data-value").split("_");
                 var dataLabel = jQuery(this).attr('data-label');
@@ -831,6 +844,7 @@ leantime.ticketsController = (function () {
                         jQuery("#statusDropdownMenuLink" + ticketId + " span.text").text(dataLabel);
                         jQuery("#statusDropdownMenuLink" + ticketId).removeClass().addClass(className + " dropdown-toggle f-left status ");
                         jQuery.growl({message: leantime.i18n.__("short_notifications.status_updated"), style: "success"});
+                        triggerSubtaskRefreshIfNeeded(sourceElement);
 
                         leantime.handleAsyncResponse(response);
 
@@ -882,6 +896,7 @@ leantime.ticketsController = (function () {
     var initAsyncInputChange = function () {
 
         jQuery(".asyncInputUpdate").on("change", function () {
+            var inputElement = this;
             var dataLabel = jQuery(this).attr('data-label').split("-");
 
             if (dataLabel.length == 2) {
@@ -903,6 +918,7 @@ leantime.ticketsController = (function () {
                 ).done(
                     function () {
                         jQuery.growl({message: leantime.i18n.__("notifications.subtask_saved"), style: "success"});
+                        triggerSubtaskRefreshIfNeeded(inputElement);
                     }
                 );
             }
@@ -1000,6 +1016,7 @@ leantime.ticketsController = (function () {
 
         leantime.dateController.initDatePicker(".quickDueDates, .duedates", function(date, instance) {
             //TODO: Update to use htmx, this is awful
+            var sourceElement = this;
             var day = instance.currentDay;
             var month = instance.currentMonth;
             var year = instance.currentYear;
@@ -1011,6 +1028,7 @@ leantime.ticketsController = (function () {
 
             leantime.ticketsRepository.updateDueDates(id, parsed, function () {
                 jQuery.growl({message: leantime.i18n.__("short_notifications.duedate_updated"), style: "success"});
+                triggerSubtaskRefreshIfNeeded(sourceElement);
             });
 
         });

--- a/app/Domain/Tickets/Repositories/Tickets.php
+++ b/app/Domain/Tickets/Repositories/Tickets.php
@@ -373,11 +373,13 @@ class Tickets
         if ($includeCounts) {
             $query->selectRaw('COALESCE(comment_agg.comment_count, 0) AS '.$this->dbHelper->wrapColumn('commentCount'))
                 ->selectRaw('COALESCE(file_agg.file_count, 0) AS '.$this->dbHelper->wrapColumn('fileCount'))
-                ->selectRaw('COALESCE(subtask_agg.subtask_count, 0) AS '.$this->dbHelper->wrapColumn('subtaskCount'));
+                ->selectRaw('COALESCE(subtask_agg.subtask_count, 0) AS '.$this->dbHelper->wrapColumn('subtaskCount'))
+                ->selectRaw('COALESCE(subtask_agg.done_subtask_count, 0) AS '.$this->dbHelper->wrapColumn('doneSubtaskCount'));
         } else {
             $query->selectRaw('0 AS '.$this->dbHelper->wrapColumn('commentCount'))
                 ->selectRaw('0 AS '.$this->dbHelper->wrapColumn('fileCount'))
-                ->selectRaw('0 AS '.$this->dbHelper->wrapColumn('subtaskCount'));
+                ->selectRaw('0 AS '.$this->dbHelper->wrapColumn('subtaskCount'))
+                ->selectRaw('0 AS '.$this->dbHelper->wrapColumn('doneSubtaskCount'));
         }
 
         $query->leftJoin('zp_projects', 'zp_tickets.projectId', '=', 'zp_projects.id')
@@ -434,6 +436,7 @@ class Tickets
                     $this->connection->table('zp_tickets')
                         ->select('dependingTicketId')
                         ->selectRaw('COUNT(*) as subtask_count')
+                        ->selectRaw('SUM(CASE WHEN status = 0 THEN 1 ELSE 0 END) as done_subtask_count')
                         ->where('dependingTicketId', '>', 0)
                         ->groupBy('dependingTicketId'),
                     'subtask_agg',
@@ -591,6 +594,7 @@ class Tickets
             $groupByColumns[] = 'comment_agg.comment_count';
             $groupByColumns[] = 'file_agg.file_count';
             $groupByColumns[] = 'subtask_agg.subtask_count';
+            $groupByColumns[] = 'subtask_agg.done_subtask_count';
         }
 
         $query->groupBy($groupByColumns);

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -25,6 +25,7 @@ use Leantime\Domain\Sprints\Services\Sprints as SprintService;
 use Leantime\Domain\Tickets\Models\Tickets as TicketModel;
 use Leantime\Domain\Tickets\Repositories\TicketHistory;
 use Leantime\Domain\Tickets\Repositories\Tickets as TicketRepository;
+use Leantime\Domain\Tickets\Support\SubtaskProgress;
 use Leantime\Domain\Timesheets\Repositories\Timesheets as TimesheetRepository;
 use Leantime\Domain\Timesheets\Services\Timesheets as TimesheetService;
 
@@ -1760,9 +1761,42 @@ class Tickets
      */
     public function getAllSubtasks(int $ticketId): false|array
     {
+        $subtasks = $this->ticketRepository->getAllSubtasks($ticketId);
 
-        // TODO: Refactor to be recursive
-        return $this->ticketRepository->getAllSubtasks($ticketId);
+        if ($subtasks === false) {
+            return false;
+        }
+
+        return SubtaskProgress::sortByDueDate($subtasks);
+    }
+
+    /**
+     * @return array{completed: int, total: int}
+     */
+    public function getSubtaskSummary(int $ticketId): array
+    {
+        $subtasks = $this->getAllSubtasks($ticketId);
+
+        return SubtaskProgress::summarize(is_array($subtasks) ? $subtasks : []);
+    }
+
+    public function syncParentCompletionFromSubtasks(int $parentTicketId): void
+    {
+        $parentTicket = $this->getTicket($parentTicketId);
+        if (! $parentTicket) {
+            return;
+        }
+
+        $subtasks = $this->getAllSubtasks($parentTicketId);
+        if (! is_array($subtasks) || ! SubtaskProgress::areAllComplete($subtasks)) {
+            return;
+        }
+
+        if ((string) $parentTicket->status === '0') {
+            return;
+        }
+
+        $this->ticketRepository->updateTicketStatus($parentTicketId, 0);
     }
 
     /**
@@ -2046,13 +2080,12 @@ class Tickets
      */
     public function updateTicket($values): array|bool
     {
+        $currentTicket = $this->getTicket($values['id']);
+        if (! $currentTicket) {
+            return ['msg' => 'This ticket id does not exist within your leantime account.', 'type' => 'error'];
+        }
+
         if (! isset($values['headline'])) {
-            $currentTicket = $this->getTicket($values['id']);
-
-            if (! $currentTicket) {
-                return ['msg' => 'This ticket id does not exist within your leantime account.', 'type' => 'error'];
-            }
-
             $values['headline'] = $currentTicket->headline;
         }
 
@@ -2115,6 +2148,11 @@ class Tickets
             $this->projectService->notifyProjectUsers($notification);
 
             self::dispatchEvent('ticket_updated');
+
+            $parentTicketId = (int) ($values['dependingTicketId'] ?: $currentTicket->dependingTicketId ?: 0);
+            if ($parentTicketId > 0) {
+                $this->syncParentCompletionFromSubtasks($parentTicketId);
+            }
 
             return true;
         }
@@ -2304,6 +2342,8 @@ class Tickets
 
             self::dispatchEvent('ticket_updated');
         }
+
+        $this->syncParentCompletionFromSubtasks((int) $parentTicket->id);
 
         return true;
     }

--- a/app/Domain/Tickets/Support/SubtaskProgress.php
+++ b/app/Domain/Tickets/Support/SubtaskProgress.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Leantime\Domain\Tickets\Support;
+
+class SubtaskProgress
+{
+    /**
+     * @param  array<int, array<string, mixed>>  $subtasks
+     * @return array<int, array<string, mixed>>
+     */
+    public static function sortByDueDate(array $subtasks): array
+    {
+        usort($subtasks, function (array $left, array $right): int {
+            [$leftHasDueDate, $leftTimestamp] = self::extractDueDateSortValue($left['dateToFinish'] ?? null);
+            [$rightHasDueDate, $rightTimestamp] = self::extractDueDateSortValue($right['dateToFinish'] ?? null);
+
+            if ($leftHasDueDate !== $rightHasDueDate) {
+                return $leftHasDueDate ? -1 : 1;
+            }
+
+            if ($leftHasDueDate && $leftTimestamp !== $rightTimestamp) {
+                return $leftTimestamp <=> $rightTimestamp;
+            }
+
+            $leftSortIndex = (int) ($left['sortindex'] ?? 0);
+            $rightSortIndex = (int) ($right['sortindex'] ?? 0);
+            if ($leftSortIndex !== $rightSortIndex) {
+                return $leftSortIndex <=> $rightSortIndex;
+            }
+
+            return ((int) ($right['id'] ?? 0)) <=> ((int) ($left['id'] ?? 0));
+        });
+
+        return $subtasks;
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $subtasks
+     * @return array{completed: int, total: int}
+     */
+    public static function summarize(array $subtasks): array
+    {
+        $completed = 0;
+
+        foreach ($subtasks as $subtask) {
+            if (self::isComplete($subtask)) {
+                $completed++;
+            }
+        }
+
+        return [
+            'completed' => $completed,
+            'total' => count($subtasks),
+        ];
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $subtasks
+     */
+    public static function areAllComplete(array $subtasks): bool
+    {
+        if ($subtasks === []) {
+            return false;
+        }
+
+        foreach ($subtasks as $subtask) {
+            if (! self::isComplete($subtask)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @return array{0: bool, 1: int}
+     */
+    private static function extractDueDateSortValue(mixed $value): array
+    {
+        if (! is_string($value) || trim($value) === '' || $value === '0000-00-00 00:00:00' || $value === '1969-12-31 00:00:00') {
+            return [false, PHP_INT_MAX];
+        }
+
+        $timestamp = strtotime($value);
+        if ($timestamp === false) {
+            return [false, PHP_INT_MAX];
+        }
+
+        return [true, $timestamp];
+    }
+
+    /**
+     * @param  array<string, mixed>  $subtask
+     */
+    private static function isComplete(array $subtask): bool
+    {
+        return (string) ($subtask['status'] ?? '') === '0';
+    }
+}

--- a/app/Domain/Tickets/Templates/partials/subtasks.blade.php
+++ b/app/Domain/Tickets/Templates/partials/subtasks.blade.php
@@ -1,5 +1,12 @@
 
 <ul class="sortableTicketList" style="margin-bottom:120px;">
+    @if (($subtaskSummary['total'] ?? 0) > 0)
+        <li class="subtaskProgressSummary">
+            <span class="fa fa-diagram-successor"></span>
+            {{ $subtaskSummary['completed'] }}/{{ $subtaskSummary['total'] }}
+        </li>
+    @endif
+
     <li class="">
         <a href="javascript:void(0);" class="quickAddLink" id="subticket_new_link" onclick="jQuery('#subticket_new').toggle('fast', function() {jQuery(this).find('input[name=headline]').focus();}); jQuery(this).toggle('fast');"><i class="fas fa-plus-circle"></i> {{ __("links.add_task") }}</a>
         <div class="ticketBox hideOnLoad" id="subticket_new" >

--- a/app/Domain/Tickets/Templates/showKanban.tpl.php
+++ b/app/Domain/Tickets/Templates/showKanban.tpl.php
@@ -366,7 +366,7 @@ $allTickets = $group['items'];
                                                     <?php } ?>
 
                                                     <?php if ($row['subtaskCount'] > 0) {?>
-                                                        <a id="subtaskLink_<?php echo $row['id']; ?>" href="#/tickets/showTicket/<?php echo $row['id']; ?>" class="subtaskLineLink"> <span class="fa fa-diagram-successor"></span> <?php echo $row['subtaskCount'] ?></a>&nbsp;
+                                                        <a id="subtaskLink_<?php echo $row['id']; ?>" href="#/tickets/showTicket/<?php echo $row['id']; ?>" class="subtaskLineLink"> <span class="fa fa-diagram-successor"></span> <?php echo ($row['doneSubtaskCount'] ?? 0).'/'.$row['subtaskCount'] ?></a>&nbsp;
                                                     <?php } ?>
                                                     <?php if ($row['tags'] != '') {?>
                                                         <?php $tagsArray = explode(',', $row['tags']); ?>

--- a/tests/Unit/app/Domain/Tickets/Support/SubtaskProgressTest.php
+++ b/tests/Unit/app/Domain/Tickets/Support/SubtaskProgressTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Unit\app\Domain\Tickets\Support;
+
+use Leantime\Domain\Tickets\Support\SubtaskProgress;
+use PHPUnit\Framework\TestCase;
+
+class SubtaskProgressTest extends TestCase
+{
+    public function test_sort_by_due_date_places_earliest_due_date_first_and_empty_dates_last(): void
+    {
+        $subtasks = [
+            ['id' => 4, 'dateToFinish' => '', 'sortindex' => 0],
+            ['id' => 3, 'dateToFinish' => '2026-03-20 00:00:00', 'sortindex' => 50],
+            ['id' => 2, 'dateToFinish' => '2026-03-15 00:00:00', 'sortindex' => 20],
+            ['id' => 1, 'dateToFinish' => '0000-00-00 00:00:00', 'sortindex' => 10],
+        ];
+
+        $sorted = SubtaskProgress::sortByDueDate($subtasks);
+
+        $this->assertSame([2, 3, 4, 1], array_column($sorted, 'id'));
+    }
+
+    public function test_summarize_counts_completed_subtasks_only_from_done_status(): void
+    {
+        $summary = SubtaskProgress::summarize([
+            ['status' => 0],
+            ['status' => '0'],
+            ['status' => 2],
+            ['status' => -1],
+        ]);
+
+        $this->assertSame(['completed' => 2, 'total' => 4], $summary);
+    }
+
+    public function test_are_all_complete_requires_at_least_one_subtask_and_all_done(): void
+    {
+        $this->assertFalse(SubtaskProgress::areAllComplete([]));
+        $this->assertFalse(SubtaskProgress::areAllComplete([
+            ['status' => 0],
+            ['status' => 4],
+        ]));
+        $this->assertTrue(SubtaskProgress::areAllComplete([
+            ['status' => 0],
+            ['status' => '0'],
+        ]));
+    }
+}


### PR DESCRIPTION
## Intent summary
Make parent tasks behave more predictably around subtasks by keeping subtasks sorted by due date, exposing completed/total progress counts, and auto-completing the parent task when every subtask reaches done.

## User stories / acceptance criteria
- As a user, subtasks stay ordered by due date instead of jumping based on last edit time.
- As a user, I can see subtask completion progress on the parent task as `done/total`.
- As a user, when every subtask is fully done, the parent task is automatically marked done in storage.
- As a user, inline subtask edits refresh the subtask panel so the ordering and counters stay current.

## Key files changed
- `.gitignore`
- `app/Domain/Tickets/Hxcontrollers/Subtasks.php`
- `app/Domain/Tickets/Js/ticketsController.js`
- `app/Domain/Tickets/Repositories/Tickets.php`
- `app/Domain/Tickets/Services/Tickets.php`
- `app/Domain/Tickets/Support/SubtaskProgress.php`
- `app/Domain/Tickets/Templates/partials/subtasks.blade.php`
- `app/Domain/Tickets/Templates/showKanban.tpl.php`
- `tests/Unit/app/Domain/Tickets/Support/SubtaskProgressTest.php`

## How to test
- `php -l app/Domain/Tickets/Support/SubtaskProgress.php`
- `php -l app/Domain/Tickets/Services/Tickets.php`
- `php -l app/Domain/Tickets/Hxcontrollers/Subtasks.php`
- `php -l app/Domain/Tickets/Templates/partials/subtasks.blade.php`
- `php -l app/Domain/Tickets/Templates/showKanban.tpl.php`
- `php -l app/Domain/Tickets/Repositories/Tickets.php`
- `vendor\bin\codecept run Unit tests/Unit/app/Domain/Tickets/Support/SubtaskProgressTest.php`
- JS parse check for `app/Domain/Tickets/Js/ticketsController.js`
- In the UI, edit subtask due dates/statuses and confirm the parent subtask list reorders by due date, shows `done/total`, and the parent status flips to done once all subtasks are done.

## QA checklist
- [ ] Subtasks are ordered by due date, with undated items last.
- [ ] Subtask progress shows as `done/total` in the subtask panel.
- [ ] Kanban cards show `done/total` for subtask badges.
- [ ] Completing the final subtask marks the parent task done.
- [ ] Inline subtask edits refresh the subtask panel without a full page reload.

## Approval conditions
- Focused unit test passes.
- PHP/JS syntax checks pass.
- Manual subtask flow smoke test passes.
