### PR TITLE
improve task search scope and visibility filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ tests/Httprequests/http-client.private.env.json
 /AGENTS.md
 /AGENTS.behavior.md
 /harness.json
+/.env
+/.env.*
+!/.env.example

--- a/app/Domain/Tickets/Js/ticketsController.js
+++ b/app/Domain/Tickets/Js/ticketsController.js
@@ -1160,6 +1160,10 @@ leantime.ticketsController = (function () {
             var groupBy = jQuery("input[name='groupBy']:checked").val();
             var showTasks = jQuery("input[name='showTasks']:checked").val();
 
+            if (project === "all") {
+                milestones = "";
+            }
+
             var query = "?search=true";
             if (project != "" && project != undefined) {
                 query = query + "&projectId=" + project}
@@ -1203,6 +1207,10 @@ leantime.ticketsController = (function () {
             var status = jQuery("#statusSelect").val();
             var sort = jQuery("#sortBySelect").val();
             var groupBy = jQuery("input[name='groupBy']:checked").val();
+
+            if (project === "all") {
+                milestones = "";
+            }
 
             var query = "?search=true";
         if (project != "" && project != undefined) {

--- a/app/Domain/Tickets/Repositories/Tickets.php
+++ b/app/Domain/Tickets/Repositories/Tickets.php
@@ -550,7 +550,16 @@ class Tickets
                 $q->whereRaw($findInSetSql, [$term])
                     ->orWhere('zp_tickets.headline', 'LIKE', $termWild)
                     ->orWhere('zp_tickets.description', 'LIKE', $termWild)
-                    ->orWhere('zp_tickets.id', 'LIKE', $termWild);
+                    ->orWhere('zp_tickets.id', 'LIKE', $termWild)
+                    ->orWhere('zp_projects.name', 'LIKE', $termWild)
+                    ->orWhere('milestone.headline', 'LIKE', $termWild)
+                    ->orWhere('parent.headline', 'LIKE', $termWild)
+                    ->orWhere('t1.firstname', 'LIKE', $termWild)
+                    ->orWhere('t1.lastname', 'LIKE', $termWild)
+                    ->orWhereRaw("CONCAT(t1.firstname, ' ', t1.lastname) LIKE ?", [$termWild])
+                    ->orWhere('t2.firstname', 'LIKE', $termWild)
+                    ->orWhere('t2.lastname', 'LIKE', $termWild)
+                    ->orWhereRaw("CONCAT(t2.firstname, ' ', t2.lastname) LIKE ?", [$termWild]);
             });
         }
 

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -257,6 +257,10 @@ class Tickets
             $searchCriteria['currentProject'] = $searchParams['currentProject'];
         }
 
+        if (isset($searchParams['projectId']) === true) {
+            $searchCriteria['currentProject'] = $searchParams['projectId'] === 'all' ? '' : $searchParams['projectId'];
+        }
+
         if (isset($searchParams['currentUser']) === true) {
             $searchCriteria['currentUser'] = $searchParams['currentUser'];
         }
@@ -2787,13 +2791,8 @@ class Tickets
         $sprints = $this->sprintService->getAllSprints(session('currentProject'));
         $futureSprints = $this->sprintService->getAllFutureSprints((int) session('currentProject'));
 
-        $users = $this->projectService->getUsersAssignedToProject(session('currentProject'));
-
-        $milestones = $this->getAllMilestones([
-            'sprint' => '',
-            'type' => 'milestone',
-            'currentProject' => session('currentProject'),
-        ]);
+        $users = $this->getTicketFilterUsers($searchCriteria['currentProject']);
+        $milestones = $this->getTicketFilterMilestones($searchCriteria['currentProject']);
 
         $groupByOptions = $this->getGroupByFieldOptions();
         $newField = $this->getNewFieldOptions();
@@ -2826,6 +2825,55 @@ class Tickets
             'sortOptions' => $sortOptions,
             'searchParams' => $searchUrlString,
         ];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function getTicketFilterUsers(string|int|null $projectId): array
+    {
+        if ($projectId !== null && $projectId !== '' && $projectId !== 'all') {
+            return $this->projectService->getUsersAssignedToProject((int) $projectId);
+        }
+
+        $usersById = [];
+        $projects = $this->projectService->getProjectsUserHasAccessTo(session('userdata.id'));
+
+        if (is_array($projects)) {
+            foreach ($projects as $project) {
+                $projectUsers = $this->projectService->getUsersAssignedToProject((int) $project['id']);
+                foreach ($projectUsers as $user) {
+                    $usersById[$user['id']] = $user;
+                }
+            }
+        }
+
+        return array_values($usersById);
+    }
+
+    /**
+     * @return array<int, object>
+     */
+    private function getTicketFilterMilestones(string|int|null $projectId): array
+    {
+        if ($projectId !== null && $projectId !== '' && $projectId !== 'all') {
+            return $this->getAllMilestones([
+                'sprint' => '',
+                'type' => 'milestone',
+                'currentProject' => $projectId,
+            ]);
+        }
+
+        $flattenedMilestones = [];
+        $milestonesByProject = $this->getAllMilestonesByUserProjects(session('userdata.id'));
+
+        foreach ($milestonesByProject as $projectMilestones) {
+            foreach ($projectMilestones as $milestone) {
+                $flattenedMilestones[$milestone->id] = $milestone;
+            }
+        }
+
+        return array_values($flattenedMilestones);
     }
 
     /**

--- a/app/Domain/Tickets/Templates/submodules/ticketFilter.sub.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketFilter.sub.php
@@ -16,7 +16,7 @@ $taskToggle = $tpl->get('enableTaskTypeToggle');
 <form action="" method="get" id="ticketSearch">
 
     <input type="hidden" value="1" name="search"/>
-    <input type="hidden" value="<?php echo session('currentProject'); ?>" name="projectId" id="projectIdInput"/>
+    <input type="hidden" value="<?php echo $searchCriteria['currentProject'] === '' ? 'all' : session('currentProject'); ?>" name="projectId" id="projectIdInput"/>
 
     <div class="filterWrapper" style="display:inline-block; position:relative; vertical-align: bottom; margin-bottom:20px;">
         <a onclick="leantime.ticketsController.toggleFilterBar();" style="margin-right:5px;"
@@ -64,6 +64,20 @@ $taskToggle = $tpl->get('enableTaskTypeToggle');
                 <?php $tpl->dispatchTplEvent('filters.beforeFirstBarField'); ?>
 
                 <div class="">
+                    <label class="inline"><?= $tpl->__('label.project') ?></label>
+                    <div class="form-group">
+                        <span class="checkbox">
+                            <input
+                                type="checkbox"
+                                id="allProjectsToggle"
+                                <?= $searchCriteria['currentProject'] === '' ? "checked='checked'" : '' ?>
+                            />
+                            <label for="allProjectsToggle">Search all accessible projects</label>
+                        </span>
+                    </div>
+                </div>
+
+                <div class="">
                     <label class="inline"><?= $tpl->__('label.user') ?></label>
                     <div class="form-group">
                         <select data-placeholder="<?= $tpl->__('input.placeholders.filter_by_user') ?>"  title="<?= $tpl->__('input.placeholders.filter_by_user') ?>" name="users" multiple="multiple" class="user-select" id="userSelect">
@@ -92,11 +106,16 @@ $taskToggle = $tpl->get('enableTaskTypeToggle');
                                 foreach ($tpl->get('milestones') as $milestoneRow) {   ?>
                                     <?php echo "<option value='".$milestoneRow->id."'";
 
-                                    if (isset($searchCriteria['milestone']) && ($searchCriteria['milestone'] == $milestoneRow->id) && array_search($milestoneRow->id, explode(',', $searchCriteria['milestone'])) !== false) {
+                                    if (isset($searchCriteria['milestone']) && array_search((string) $milestoneRow->id, explode(',', $searchCriteria['milestone']), true) !== false) {
                                         echo " selected='selected' ";
                                     }
 
-                                    echo '>'.$tpl->escape($milestoneRow->headline).'</option>'; ?>
+                                    $milestoneLabel = $tpl->escape($milestoneRow->headline);
+                                    if ($searchCriteria['currentProject'] === '' && isset($milestoneRow->projectName) && $milestoneRow->projectName !== '') {
+                                        $milestoneLabel = $tpl->escape($milestoneRow->projectName).' / '.$milestoneLabel;
+                                    }
+
+                                    echo '>'.$milestoneLabel.'</option>'; ?>
 
                                 <?php }
                                 }?>
@@ -174,7 +193,7 @@ $taskToggle = $tpl->get('enableTaskTypeToggle');
                         <input type="text" name="termInput" id="termInput"
                         style="width: 230px"
                         value="<?= $searchCriteria['term']?>"
-                        placeholder="<?= $tpl->__('label.search_term')?>">
+                        placeholder="Tasks, people, projects, milestones">
                     </div>
                 </div>
 
@@ -241,6 +260,12 @@ $taskToggle = $tpl->get('enableTaskTypeToggle');
                 placeholderText: 'All Statuses',
             },
         });
+
+        jQuery('#allProjectsToggle').on('change', function () {
+            var useAllProjects = jQuery(this).is(':checked');
+            jQuery('#projectIdInput').val(useAllProjects ? 'all' : '<?= session('currentProject'); ?>');
+            jQuery('#milestoneSelect').prop('disabled', useAllProjects);
+        }).trigger('change');
 
         leantime.ticketsController.initTicketSearchSubmit('<?= $currentUrlPath; ?>');
 

--- a/tests/Unit/app/Domain/Tickets/Services/TicketsServiceTest.php
+++ b/tests/Unit/app/Domain/Tickets/Services/TicketsServiceTest.php
@@ -170,4 +170,15 @@ class TicketsServiceTest extends TestCase
         $this->assertArrayNotHasKey('timeFrom', $result);
         $this->assertArrayNotHasKey('timeTo', $result);
     }
+
+    public function test_prepare_ticket_search_array_maps_all_projects_scope(): void
+    {
+        $criteria = $this->ticketsService->prepareTicketSearchArray([
+            'projectId' => 'all',
+            'term' => 'alex',
+        ]);
+
+        $this->assertSame('', $criteria['currentProject']);
+        $this->assertSame('alex', $criteria['term']);
+    }
 }


### PR DESCRIPTION
## Intent summary
Improve task search and visibility so people can find assigned work more reliably, search across accessible projects, and use milestone visibility filters without losing default all-milestone behavior inside a project.

## User stories / acceptance criteria
- As a user, I can search tasks by person name, project name, milestone name, or task text.
- As a user, I can switch the task filter to search across all accessible projects.
- As a user, milestone filters still default to showing all milestones, and selected milestone filters persist correctly.
- As a user, cross-project search does not incorrectly reuse milestone filters from a single-project scope.

## Key files changed
- `.gitignore`
- `app/Domain/Tickets/Js/ticketsController.js`
- `app/Domain/Tickets/Repositories/Tickets.php`
- `app/Domain/Tickets/Services/Tickets.php`
- `app/Domain/Tickets/Templates/submodules/ticketFilter.sub.php`
- `tests/Unit/app/Domain/Tickets/Services/TicketsServiceTest.php`

## How to test
- `php -l app/Domain/Tickets/Services/Tickets.php`
- `php -l app/Domain/Tickets/Repositories/Tickets.php`
- `php -l app/Domain/Tickets/Templates/submodules/ticketFilter.sub.php`
- `php -l tests/Unit/app/Domain/Tickets/Services/TicketsServiceTest.php`
- `vendor\bin\codecept run Unit tests/Unit/app/Domain/Tickets/Services/TicketsServiceTest.php`
- JS parse check for `app/Domain/Tickets/Js/ticketsController.js`
- In the UI, open task filters and confirm:
  - typing a user/project/milestone name returns matching tasks
  - enabling all-project search broadens results beyond the current project
  - milestone selections persist correctly in project-scoped searches

## QA checklist
- [ ] Searching by assignee name returns matching tasks.
- [ ] Searching by project or milestone name returns matching tasks.
- [ ] All-project scope searches across accessible projects.
- [ ] Milestone filter remains available in project scope and is disabled in all-project scope.
- [ ] Existing current-project searches still work.

## Approval conditions
- PHP/JS syntax checks pass.
- Focused unit test passes.
- Manual task-filter smoke test passes.
