### PR TITLE
add due date urgency indicators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,9 @@ config/.env
 tests/Httprequests/http-client.private.env.json
 .claude/docs/personal-companion-requirements.md
 .claude/docs/git-workflow.md
+/.env
+/.env.*
+!/.env.example
 
 # Blue Fission Codex harness
 /docker/

--- a/app/Domain/Tickets/Js/ticketsController.js
+++ b/app/Domain/Tickets/Js/ticketsController.js
@@ -1598,7 +1598,7 @@ leantime.ticketsController = (function () {
             var columnIndex = false;
 
 
-            var defaultOrder = [];
+            var defaultOrder = [[9, 'asc']];
 
             var allTickets = jQuery(".ticketTable").DataTable({
                 "language": {

--- a/app/Domain/Tickets/Repositories/Tickets.php
+++ b/app/Domain/Tickets/Repositories/Tickets.php
@@ -78,6 +78,13 @@ class Tickets
 
     public array $efforts = ['0.5' => '< 2min', '1' => 'XS', '2' => 'S', '3' => 'M', '5' => 'L', '8' => 'XL', '13' => 'XXL'];
 
+    private function getDueDateSortExpression(): string
+    {
+        $column = $this->dbHelper->wrapColumn('zp_tickets.dateToFinish');
+
+        return "CASE WHEN {$column} IS NULL OR {$column} = '' OR {$column} = '0000-00-00 00:00:00' OR {$column} = '1969-12-31 00:00:00' THEN 1 ELSE 0 END";
+    }
+
     public array $type = ['task', 'subtask', 'story', 'bug'];
 
     public array $typeIcons = ['story' => 'fa-book', 'task' => 'fa-check-square', 'subtask' => 'fa-diagram-successor', 'bug' => 'fa-bug'];
@@ -603,7 +610,7 @@ class Tickets
             $query->orderBy('zp_tickets.kanbanSortIndex', 'ASC')
                 ->orderByDesc('zp_tickets.id');
         } elseif ($sort == 'duedate') {
-            $query->orderByRaw('('.$this->dbHelper->wrapColumn('zp_tickets.dateToFinish').' IS NULL)')
+            $query->orderByRaw($this->getDueDateSortExpression())
                 ->orderBy('zp_tickets.dateToFinish', 'ASC')
                 ->orderBy('zp_tickets.sortindex', 'ASC')
                 ->orderByDesc('zp_tickets.id');
@@ -1232,7 +1239,7 @@ class Tickets
             $query->orderBy('zp_tickets.kanbanSortIndex', 'ASC')
                 ->orderByDesc('zp_tickets.id');
         } elseif ($sort == 'duedate') {
-            $query->orderByRaw('('.$this->dbHelper->wrapColumn('zp_tickets.dateToFinish').' IS NULL)')
+            $query->orderByRaw($this->getDueDateSortExpression())
                 ->orderBy('zp_tickets.dateToFinish', 'ASC')
                 ->orderBy('zp_tickets.sortindex', 'ASC')
                 ->orderByDesc('zp_tickets.id');

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -2766,7 +2766,15 @@ class Tickets
         $currentSprint = $this->sprintService->getCurrentSprintId((int) session('currentProject'));
 
         $searchCriteria = $this->prepareTicketSearchArray($params);
-        $searchCriteria['orderBy'] = 'kanbansort';
+
+        if (
+            ! isset($params['orderBy'])
+            || $params['orderBy'] === ''
+            || $params['orderBy'] === 'sortIndex'
+            || $params['orderBy'] === 'kanbansort'
+        ) {
+            $searchCriteria['orderBy'] = 'duedate';
+        }
 
         $allTickets = $this->getAllGrouped($searchCriteria);
         $allTicketStates = $this->getStatusLabels();

--- a/app/Domain/Tickets/Support/DueDateAlert.php
+++ b/app/Domain/Tickets/Support/DueDateAlert.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Leantime\Domain\Tickets\Support;
+
+use Carbon\CarbonImmutable;
+
+class DueDateAlert
+{
+    private const INVALID_DUE_DATES = [
+        '',
+        '0000-00-00 00:00:00',
+        '1969-12-31 00:00:00',
+    ];
+
+    public function forDate(?string $dateToFinish, ?CarbonImmutable $now = null): ?string
+    {
+        if ($dateToFinish === null || in_array($dateToFinish, self::INVALID_DUE_DATES, true)) {
+            return null;
+        }
+
+        try {
+            $dueDate = CarbonImmutable::parse($dateToFinish);
+        } catch (\Throwable) {
+            return null;
+        }
+
+        $today = ($now ?? CarbonImmutable::now())->startOfDay();
+
+        if ($dueDate->lt($today)) {
+            return 'overdue';
+        }
+
+        if ($dueDate->lte($today->addDays(3)->endOfDay())) {
+            return 'dueSoon';
+        }
+
+        return null;
+    }
+}

--- a/app/Domain/Tickets/Templates/partials/ticketCard.blade.php
+++ b/app/Domain/Tickets/Templates/partials/ticketCard.blade.php
@@ -1,3 +1,12 @@
+@php
+    $dueDateAlert = app(\Leantime\Domain\Tickets\Support\DueDateAlert::class)->forDate($row['dateToFinish'] ?? null);
+    $dueDateClass = match ($dueDateAlert) {
+        'overdue' => 'ticket-due-date ticket-due-date--overdue',
+        'dueSoon' => 'ticket-due-date ticket-due-date--soon',
+        default => 'ticket-due-date',
+    };
+@endphp
+
 <div class="ticketBox fixed priority-border-{{ $row['priority'] }}" data-val="{{ $row['id'] }}">
     <div class="row">
         <div class="col-md-8 titleContainer">
@@ -29,7 +38,7 @@
             <div class="col-md-4" style="padding:0 15px;">
                 @if($cardType == "full")
                     <i class="fa-solid fa-business-time infoIcon" data-tippy-content=" {{ __("label.due") }}"></i>
-                    <input type="text" title="{{ __("label.due") }}" value="{{ format($row['dateToFinish'])->date(__("text.anytime")) }}" class="duedates secretInput" style="margin-left:0px;" data-id="{{ $row['id'] }}" name="date" />
+                    <input type="text" title="{{ __("label.due") }}" value="{{ format($row['dateToFinish'])->date(__("text.anytime")) }}" class="duedates secretInput {{ $dueDateClass }}" style="margin-left:0px;" data-id="{{ $row['id'] }}" name="date" />
                 @endif
             </div>
 

--- a/app/Domain/Tickets/Templates/showAll.tpl.php
+++ b/app/Domain/Tickets/Templates/showAll.tpl.php
@@ -330,15 +330,24 @@ $tpl->dispatchTplEvent('filters.beforeLefthandSectionClose');
                             </td>
 
                             <?php
-                            if ($row['dateToFinish'] == '0000-00-00 00:00:00' || $row['dateToFinish'] == '1969-12-31 00:00:00') {
+                            $dueDateAlert = app(\Leantime\Domain\Tickets\Support\DueDateAlert::class)->forDate($row['dateToFinish'] ?? null);
+                            $dueDateClass = match ($dueDateAlert) {
+                                'overdue' => 'ticket-due-date ticket-due-date--overdue',
+                                'dueSoon' => 'ticket-due-date ticket-due-date--soon',
+                                default => 'ticket-due-date',
+                            };
+
+                            if ($row['dateToFinish'] == '0000-00-00 00:00:00' || $row['dateToFinish'] == '1969-12-31 00:00:00' || $row['dateToFinish'] == null) {
                                 $date = $tpl->__('text.anytime');
+                                $dateOrder = '9999-12-31 23:59:59';
                             } else {
                                 $date = new DateTime($row['dateToFinish']);
                                 $date = $date->format($tpl->__('language.dateformat'));
+                                $dateOrder = $row['dateToFinish'];
                             }
                         ?>
-                            <td data-order="<?= $row['dateToFinish'] ?>" >
-                                <input type="text" title="<?php echo $tpl->__('label.due'); ?>" value="<?php echo $date ?>" class="quickDueDates secretInput" data-id="<?php echo $row['id']; ?>" name="date" />
+                            <td data-order="<?= $dateOrder ?>" >
+                                <input type="text" title="<?php echo $tpl->__('label.due'); ?>" value="<?php echo $date ?>" class="quickDueDates secretInput <?= $dueDateClass ?>" data-id="<?php echo $row['id']; ?>" name="date" />
                             </td>
                             <td data-order="<?= $tpl->e($row['planHours']); ?>">
                                 <input type="text" value="<?= $tpl->e($row['planHours']); ?>" name="planHours" class="small-input secretInput" onchange="leantime.ticketsController.updatePlannedHours(this, '<?= $row['id']?>'); jQuery(this).parent().attr('data-order',jQuery(this).val());" />

--- a/app/Domain/Tickets/Templates/showKanban.tpl.php
+++ b/app/Domain/Tickets/Templates/showKanban.tpl.php
@@ -207,6 +207,14 @@ $allTickets = $group['items'];
 
                                     <?php foreach ($allTickets as $row) { ?>
                                         <?php if ($row['status'] == $key) {?>
+                                        <?php
+                                            $dueDateAlert = app(\Leantime\Domain\Tickets\Support\DueDateAlert::class)->forDate($row['dateToFinish'] ?? null);
+                                            $dueDateClass = match ($dueDateAlert) {
+                                                'overdue' => 'ticket-due-date ticket-due-date--overdue',
+                                                'dueSoon' => 'ticket-due-date ticket-due-date--soon',
+                                                default => 'ticket-due-date',
+                                            };
+                                        ?>
                                         <div class="ticketBox moveable container priority-border-<?= $row['priority']?>" id="ticket_<?php echo $row['id']; ?>">
 
                                             <div class="row" >
@@ -235,9 +243,9 @@ $allTickets = $group['items'];
                                                     </div>
                                                     <div class="tw-flex">
                                                     <?php if ($row['dateToFinish'] != '0000-00-00 00:00:00' && $row['dateToFinish'] != '1969-12-31 00:00:00') { ?>
-                                                        <div>
+                                                        <div class="<?= $dueDateClass ?>">
                                                             <?php echo $tpl->__('label.due_icon'); ?>
-                                                            <input type="text" title="<?php echo $tpl->__('label.due'); ?>" value="<?php echo format($row['dateToFinish'])->date() ?>" class="duedates secretInput" style="margin-left:0px;" data-id="<?php echo $row['id']; ?>" name="date" />
+                                                            <input type="text" title="<?php echo $tpl->__('label.due'); ?>" value="<?php echo format($row['dateToFinish'])->date() ?>" class="duedates secretInput <?= $dueDateClass ?>" style="margin-left:0px;" data-id="<?php echo $row['id']; ?>" name="date" />
                                                         </div>
                                                         <div>
                                                             <?php $tpl->dispatchTplEvent('afterDates', ['ticket' => $row]); ?>

--- a/public/assets/css/components/style.default.css
+++ b/public/assets/css/components/style.default.css
@@ -2171,6 +2171,18 @@ body .widgettitle .editHeadline:hover {
     margin: 0;
 }
 
+.ticket-due-date {
+    font-weight: 600;
+}
+
+.ticket-due-date--overdue {
+    color: var(--dark-red) !important;
+}
+
+.ticket-due-date--soon {
+    color: var(--yellow) !important;
+}
+
 #mainToggler {
     margin-bottom:15px;
     display:block;

--- a/tests/Unit/app/Domain/Tickets/Support/DueDateAlertTest.php
+++ b/tests/Unit/app/Domain/Tickets/Support/DueDateAlertTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Unit\app\Domain\Tickets\Support;
+
+use Carbon\CarbonImmutable;
+use Leantime\Domain\Tickets\Support\DueDateAlert;
+use Unit\TestCase;
+
+class DueDateAlertTest extends TestCase
+{
+    public function test_returns_overdue_for_past_due_dates(): void
+    {
+        $alert = new DueDateAlert();
+
+        $result = $alert->forDate('2026-03-10 12:00:00', CarbonImmutable::parse('2026-03-13 09:00:00'));
+
+        $this->assertSame('overdue', $result);
+    }
+
+    public function test_returns_due_soon_for_dates_within_three_days(): void
+    {
+        $alert = new DueDateAlert();
+
+        $result = $alert->forDate('2026-03-16 17:00:00', CarbonImmutable::parse('2026-03-13 09:00:00'));
+
+        $this->assertSame('dueSoon', $result);
+    }
+
+    public function test_returns_null_for_blank_or_placeholder_due_dates(): void
+    {
+        $alert = new DueDateAlert();
+        $now = CarbonImmutable::parse('2026-03-13 09:00:00');
+
+        $this->assertNull($alert->forDate(null, $now));
+        $this->assertNull($alert->forDate('', $now));
+        $this->assertNull($alert->forDate('0000-00-00 00:00:00', $now));
+        $this->assertNull($alert->forDate('1969-12-31 00:00:00', $now));
+    }
+
+    public function test_returns_null_for_dates_more_than_three_days_out(): void
+    {
+        $alert = new DueDateAlert();
+
+        $result = $alert->forDate('2026-03-20 09:00:00', CarbonImmutable::parse('2026-03-13 09:00:00'));
+
+        $this->assertNull($result);
+    }
+}


### PR DESCRIPTION
## Intent summary
Make board and table views prioritize due dates by default and visually flag urgent task deadlines.

## User stories / acceptance criteria
- Overdue task due dates render in red.
- Tasks due within 3 days render in orange/yellow.
- Kanban and table views default to due-date ordering.
- Empty placeholder due dates sort after real due dates.

## Key files changed
- `.gitignore`
- `app/Domain/Tickets/Support/DueDateAlert.php`
- `tests/Unit/app/Domain/Tickets/Support/DueDateAlertTest.php`
- `app/Domain/Tickets/Repositories/Tickets.php`
- `app/Domain/Tickets/Services/Tickets.php`
- `app/Domain/Tickets/Js/ticketsController.js`
- `app/Domain/Tickets/Templates/showKanban.tpl.php`
- `app/Domain/Tickets/Templates/showAll.tpl.php`
- `app/Domain/Tickets/Templates/partials/ticketCard.blade.php`
- `public/assets/css/components/style.default.css`

## How to test
- Open board view and confirm tasks appear in due-date order, with missing due dates later in the list.
- Open table view and confirm the default sort is ascending by due date.
- Confirm overdue due dates are red.
- Confirm tasks due within 3 days are orange/yellow.
- Confirm tasks without meaningful due dates display normally and sort last.

## QA checklist
- [ ] Kanban ordering defaults to due date
- [ ] Table ordering defaults to due date
- [ ] Overdue dates render red
- [ ] Upcoming dates within 3 days render orange/yellow
- [ ] Placeholder due dates sort last

## Approval conditions
- Browser-level check in board and table views
- No regression in editing due dates inline
