### PR TITLE
Add emoji to High Impact Next widget title

### DIFF
--- a/app/Language/en-US.ini
+++ b/app/Language/en-US.ini
@@ -2384,9 +2384,9 @@ widgets.descriptions.calendar = "The calendar widget allows you to manage your e
 
 widgets.title.my_todos = "📥 My ToDos"
 widgets.descriptions.my_todos = "Your To-Dos grouped by date, project or goals."
-widgets.title.high_impact_next = "High Impact Next"
+widgets.title.high_impact_next = "💥 High Impact Next"
 widgets.descriptions.high_impact_next = "A soft-ranked view of your open work using due dates plus focus, expected, impact, and provision tags."
-headlines.high_impact_next = "High Impact Next"
+headlines.high_impact_next = "💥 High Impact Next"
 text.high_impact_next_helper = "Advisory only. Uses due dates, priority, and recognized ticket tags to pull likely next work to the top."
 text.high_impact_next_empty = "No open assigned work is currently surfacing above the baseline priority and due-date rules."
 


### PR DESCRIPTION
## Intent summary
Add the explosion emoji before the High Impact Next widget title.

## User stories / acceptance criteria
- The dashboard widget title shows 💥 High Impact Next.
- The internal widget headline uses the same label.

## Key files changed
- pp/Language/en-US.ini

## How to test
- Open the dashboard on staging.
- Enable the High Impact Next widget if needed.
- Confirm the widget title shows 💥 High Impact Next.

## QA checklist
- Widget manager label includes the emoji.
- Widget header includes the emoji.

## Approval conditions
- Title text renders correctly without layout regression.