### PR TITLE
Add hierarchical RACI assignments and role-aware digests

### DIFF
--- a/app/Domain/Comments/Services/Comments.php
+++ b/app/Domain/Comments/Services/Comments.php
@@ -108,7 +108,12 @@ class Comments
             'text' => $linkLabel,
         ];
 
-        $notification->entity = $mapper;
+        $notification->entity = array_merge($mapper, [
+            'contextModule' => $module,
+            'contextId' => (int) $entityId,
+            'projectId' => (int) (($entity->projectId ?? session('currentProject')) ?? -1),
+            'type' => is_object($entity) ? ($entity->type ?? '') : ($entity['type'] ?? ''),
+        ]);
         $notification->module = 'comments';
         $notification->action = 'commented';
         $notification->projectId = (($entity->projectId ?? session('currentProject')) ?? -1);

--- a/app/Domain/Notifications/Listeners/NotifyProjectUsers.php
+++ b/app/Domain/Notifications/Listeners/NotifyProjectUsers.php
@@ -17,6 +17,24 @@ class NotifyProjectUsers
 
         $notifications = [];
 
+        if (isset($payload['notifications']) && is_array($payload['notifications'])) {
+            foreach ($payload['notifications'] as $notificationPayload) {
+                if (! isset($notificationPayload['user']['id'])) {
+                    continue;
+                }
+
+                $notifications[] = [
+                    'userId' => $notificationPayload['user']['id'],
+                    'type' => $payload['type'],
+                    'module' => $payload['module'],
+                    'moduleId' => $payload['moduleId'],
+                    'message' => $notificationPayload['message'] ?? $payload['message'],
+                    'datetime' => date('Y-m-d H:i:s'),
+                    'url' => $notificationPayload['url'] ?? '',
+                    'authorId' => session('userdata.id'),
+                ];
+            }
+        } else {
         foreach ($payload['users'] as $user) {
             $notifications[] = [
                 'userId' => $user['id'],
@@ -28,6 +46,7 @@ class NotifyProjectUsers
                 'url' => $payload['url'],
                 'authorId' => session('userdata.id'),
             ];
+        }
         }
 
         $notificationService->addNotifications($notifications);

--- a/app/Domain/Projects/Controllers/ShowProject.php
+++ b/app/Domain/Projects/Controllers/ShowProject.php
@@ -17,6 +17,7 @@ use Leantime\Domain\Menu\Repositories\Menu as MenuRepository;
 use Leantime\Domain\Notifications\Models\Notification;
 use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
+use Leantime\Domain\Raci\Services\RaciAssignments;
 use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
 use Leantime\Domain\Users\Repositories\Users as UserRepository;
@@ -46,6 +47,7 @@ class ShowProject extends Controller
     private CommentRepository $commentsRepo;
 
     private MenuRepository $menuRepo;
+    private RaciAssignments $raciAssignments;
 
     /**
      * init - initialize private variables
@@ -61,7 +63,8 @@ class ShowProject extends Controller
         ClientRepository $clientsRepo,
         FileRepository $fileRepo,
         CommentRepository $commentsRepo,
-        MenuRepository $menuRepo
+        MenuRepository $menuRepo,
+        RaciAssignments $raciAssignments
     ) {
 
         Auth::authOrRedirect([Roles::$owner, Roles::$admin, Roles::$manager]);
@@ -80,6 +83,7 @@ class ShowProject extends Controller
         $this->fileRepo = $fileRepo;
         $this->commentsRepo = $commentsRepo;
         $this->menuRepo = $menuRepo;
+        $this->raciAssignments = $raciAssignments;
 
         if (! session()->exists('lastPage')) {
             session(['lastPage' => CURRENT_URL]);
@@ -247,6 +251,7 @@ class ShowProject extends Controller
                         $this->tpl->setNotification($this->language->__('notification.project_has_tickets'), 'error');
                     } else {
                         $this->projectRepo->editProject($values, $id);
+                        $this->raciAssignments->saveProjectAssignments($id, $_POST);
 
                         $project['assignedUsers'] = $this->projectRepo->getUsersAssignedToProject($id, true);
 
@@ -297,6 +302,7 @@ class ShowProject extends Controller
             $this->tpl->assign('employees', $employees);
 
             $this->tpl->assign('project', $project);
+            $this->tpl->assign('projectRaci', $this->raciAssignments->getProjectAssignments($id));
 
             $this->tpl->assign('menuTypes', $this->menuRepo->getMenuTypes());
             $this->tpl->assign('projectTypes', $projectTypes);

--- a/app/Domain/Projects/Services/Projects.php
+++ b/app/Domain/Projects/Services/Projects.php
@@ -22,6 +22,8 @@ use Leantime\Domain\Notifications\Services\Messengers;
 use Leantime\Domain\Notifications\Services\Notifications as NotificationService;
 use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
 use Leantime\Domain\Queue\Repositories\Queue as QueueRepository;
+use Leantime\Domain\Raci\Services\RaciDigests;
+use Leantime\Domain\Raci\Services\RaciNotificationRouting;
 use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
 use Leantime\Domain\Tickets\Repositories\Tickets as TicketRepository;
 use Leantime\Domain\Wiki\Repositories\Wiki;
@@ -39,6 +41,8 @@ class Projects
         private LanguageCore $language,
         private Messengers $messengerService,
         private NotificationService $notificationService,
+        private RaciNotificationRouting $raciNotificationRouting,
+        private RaciDigests $raciDigests,
         protected Files $fileService,
         protected Avatarcreator $avatarcreator
     ) {}
@@ -275,14 +279,9 @@ class Projects
             }
         }
 
-        $emailMessage = $notification->message;
-        if ($notification->url !== false) {
-            $emailMessage .= " <a href='".$notification->url['url']."'>".$notification->url['text'].'</a>';
-        }
+        $routing = $this->raciNotificationRouting->resolveRecipients($notification);
 
-        // NEW Queuing messaging system
         $queue = app()->make(QueueRepository::class);
-        $queue->queueMessageToUsers($users, $emailMessage, $notification->subject, $notification->projectId);
 
         // Send to messengers
         $this->messengerService->sendNotificationToMessengers($notification, $projectName);
@@ -352,6 +351,76 @@ class Projects
         }
 
         $filteredUsersToNotify = array_filter($allUsersToNotify, fn ($u) => in_array($u['id'], $filteredIds));
+
+        if ($routing['hasScopedAssignments'] === true) {
+            $ctaUserIds = array_values(array_intersect($users, $routing['cta']));
+            $infoUserIds = array_values(array_intersect($users, $routing['info']));
+            $digestUserIds = array_values(array_intersect($users, $routing['digest']));
+
+            $ctaMessage = $notification->message;
+            if ($notification->url !== false) {
+                $ctaMessage .= " <a href='".$notification->url['url']."'>".$notification->url['text'].'</a>';
+            }
+
+            if ($ctaUserIds !== []) {
+                $queue->queueMessageToUsers($ctaUserIds, $ctaMessage, $notification->subject, $notification->projectId);
+            }
+
+            if ($infoUserIds !== []) {
+                $queue->queueMessageToUsers($infoUserIds, $notification->message, $notification->subject, $notification->projectId);
+            }
+
+            if ($digestUserIds !== []) {
+                $this->raciDigests->queueEntries($digestUserIds, $notification, $routing['cadence']);
+            }
+
+            $userLookup = [];
+            foreach ($filteredUsersToNotify as $userInfo) {
+                $userLookup[(int) $userInfo['id']] = $userInfo;
+            }
+
+            $notificationPayloads = [];
+            foreach ($ctaUserIds as $userId) {
+                if (isset($userLookup[(int) $userId])) {
+                    $notificationPayloads[] = [
+                        'user' => $userLookup[(int) $userId],
+                        'message' => $notification->message,
+                        'url' => $notification->url['url'] ?? '',
+                    ];
+                }
+            }
+
+            foreach ($infoUserIds as $userId) {
+                if (isset($userLookup[(int) $userId])) {
+                    $notificationPayloads[] = [
+                        'user' => $userLookup[(int) $userId],
+                        'message' => $notification->message,
+                        'url' => '',
+                    ];
+                }
+            }
+
+            self::dispatch_event('notifyProjectUsers', [
+                'type' => 'projectUpdate',
+                'module' => $notification->module,
+                'moduleId' => $entityId,
+                'message' => $notification->message,
+                'subject' => $notification->subject,
+                'users' => array_values($filteredUsersToNotify),
+                'url' => $notification->url['url'] ?? '',
+                'notifications' => $notificationPayloads,
+            ], 'leantime.domain.projects.services.projects.notifyProjectUsers');
+
+            return;
+        }
+
+        $emailMessage = $notification->message;
+        if ($notification->url !== false) {
+            $emailMessage .= " <a href='".$notification->url['url']."'>".$notification->url['text'].'</a>';
+        }
+
+        // NEW Queuing messaging system
+        $queue->queueMessageToUsers($users, $emailMessage, $notification->subject, $notification->projectId);
 
         /**
          * This event is fired to notify project users of important updates.

--- a/app/Domain/Projects/Templates/submodules/projectDetails.sub.php
+++ b/app/Domain/Projects/Templates/submodules/projectDetails.sub.php
@@ -9,6 +9,7 @@ foreach ($__data as $var => $val) {
 }
 $project = $tpl->get('project');
 $menuTypes = $tpl->get('menuTypes');
+$projectRaci = $tpl->get('projectRaci') ?? [];
 
 ?>
 
@@ -159,6 +160,35 @@ $menuTypes = $tpl->get('menuTypes');
                 </div>
 
 
+
+            <div class="row marginBottom" style="margin-bottom: 30px;">
+                <div class="col-md-12 ">
+                    <h4 class="widgettitle title-light"><span class="fa fa-users"></span> RACI Defaults</h4>
+                    <div class="small muted" style="margin-bottom:10px;">These assignments are the fallback for milestones and tasks that do not define their own RACI roles.</div>
+
+                    <?php foreach ([
+                        'Responsible' => 'responsible',
+                        'Accountable' => 'accountable',
+                        'Consulted' => 'consulted',
+                        'Informed' => 'informed',
+                    ] as $roleLabel => $roleKey) { ?>
+                        <div class="form-group">
+                            <label class="control-label"><?php echo $roleLabel; ?></label>
+                            <select name="raci<?php echo $roleLabel; ?>[]" class="user-select span11" multiple>
+                                <?php foreach (($project['assignedUsers'] ?? []) as $userRow) { ?>
+                                    <option value="<?php echo $userRow['id']; ?>"
+                                        <?php if (in_array((int) $userRow['id'], array_map('intval', (array) ($projectRaci[$roleKey] ?? [])), true)) {
+                                            echo " selected='selected' ";
+                                        } ?>
+                                    >
+                                        <?php echo $tpl->escape($userRow['firstname'].' '.$userRow['lastname']); ?>
+                                    </option>
+                                <?php } ?>
+                            </select>
+                        </div>
+                    <?php } ?>
+                </div>
+            </div>
 
             <div class="row marginBottom" style="margin-bottom: 30px;">
                 <div class="col-md-12">

--- a/app/Domain/Raci/Services/RaciAssignments.php
+++ b/app/Domain/Raci/Services/RaciAssignments.php
@@ -1,0 +1,257 @@
+<?php
+
+namespace Leantime\Domain\Raci\Services;
+
+use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
+use Leantime\Domain\Tickets\Repositories\Tickets as TicketRepository;
+
+class RaciAssignments
+{
+    public const ROLE_KEYS = ['responsible', 'accountable', 'consulted', 'informed'];
+
+    public function __construct(
+        private SettingRepository $settingsRepo,
+        private TicketRepository $ticketRepository,
+    ) {}
+
+    public function saveProjectAssignments(int $projectId, array $values): void
+    {
+        $this->saveAssignments($this->projectKey($projectId), $values);
+    }
+
+    public function saveMilestoneAssignments(int $milestoneId, array $values): void
+    {
+        $this->saveAssignments($this->milestoneKey($milestoneId), $values);
+    }
+
+    public function saveTicketAssignments(int $ticketId, array $values): void
+    {
+        $this->saveAssignments($this->ticketKey($ticketId), $values);
+    }
+
+    public function getProjectAssignments(int $projectId): array
+    {
+        return $this->readAssignments($this->projectKey($projectId));
+    }
+
+    public function getMilestoneAssignments(int $milestoneId): array
+    {
+        return $this->readAssignments($this->milestoneKey($milestoneId));
+    }
+
+    public function getTicketAssignments(int $ticketId): array
+    {
+        return $this->readAssignments($this->ticketKey($ticketId));
+    }
+
+    public function resolveForMilestone(array|object $milestone): array
+    {
+        $projectId = $this->extractInt($milestone, 'projectId');
+        $milestoneId = $this->extractInt($milestone, 'id');
+
+        $resolved = $this->withSource($this->getProjectAssignments($projectId), 'project');
+        $resolved = $this->overlay(
+            $resolved,
+            $this->withSource($this->getMilestoneAssignments($milestoneId), 'milestone')
+        );
+
+        return $resolved;
+    }
+
+    public function resolveForTicket(array|object $ticket): array
+    {
+        $projectId = $this->extractInt($ticket, 'projectId');
+        $milestoneId = $this->extractInt($ticket, 'milestoneid');
+        $ticketId = $this->extractInt($ticket, 'id');
+        $dependingTicketId = $this->extractInt($ticket, 'dependingTicketId');
+        $type = strtolower((string) $this->extractValue($ticket, 'type'));
+
+        $resolved = $this->withSource($this->getProjectAssignments($projectId), 'project');
+
+        if ($milestoneId > 0) {
+            $resolved = $this->overlay(
+                $resolved,
+                $this->withSource($this->getMilestoneAssignments($milestoneId), 'milestone')
+            );
+        }
+
+        if ($type === 'subtask' && $dependingTicketId > 0) {
+            $resolved = $this->overlay(
+                $resolved,
+                $this->withSource($this->getTicketAssignments($dependingTicketId), 'parent_task')
+            );
+        }
+
+        if ($ticketId > 0) {
+            $resolved = $this->overlay(
+                $resolved,
+                $this->withSource($this->getTicketAssignments($ticketId), 'task')
+            );
+        }
+
+        return $resolved;
+    }
+
+    public function toDisplayAssignments(array $resolvedAssignments, array $users): array
+    {
+        $userMap = [];
+        foreach ($users as $user) {
+            $id = (int) ($user['id'] ?? 0);
+            if ($id <= 0) {
+                continue;
+            }
+
+            $userMap[$id] = trim((string) ($user['firstname'] ?? '').' '.(string) ($user['lastname'] ?? ''));
+        }
+
+        $display = [];
+        foreach (self::ROLE_KEYS as $roleKey) {
+            $ids = array_values(array_filter(
+                array_map('intval', (array) ($resolvedAssignments[$roleKey] ?? [])),
+                static fn (int $id): bool => $id > 0
+            ));
+
+            $display[$roleKey] = [
+                'ids' => $ids,
+                'names' => array_values(array_filter(array_map(
+                    static fn (int $id) => $userMap[$id] ?? null,
+                    $ids
+                ))),
+                'source' => (string) ($resolvedAssignments['_sources'][$roleKey] ?? 'none'),
+            ];
+        }
+
+        return $display;
+    }
+
+    private function saveAssignments(string $settingKey, array $values): void
+    {
+        $normalized = $this->normalizeAssignments($values);
+
+        if ($this->isEmptyAssignments($normalized)) {
+            $this->settingsRepo->deleteSetting($settingKey);
+
+            return;
+        }
+
+        $this->settingsRepo->saveSetting($settingKey, json_encode($normalized, JSON_THROW_ON_ERROR));
+    }
+
+    private function readAssignments(string $settingKey): array
+    {
+        $raw = $this->settingsRepo->getSetting($settingKey, false);
+        if (! is_string($raw) || trim($raw) === '') {
+            return $this->emptyAssignments();
+        }
+
+        $decoded = json_decode($raw, true);
+        if (! is_array($decoded)) {
+            return $this->emptyAssignments();
+        }
+
+        return $this->normalizeAssignments($decoded);
+    }
+
+    private function normalizeAssignments(array $values): array
+    {
+        return [
+            'responsible' => $this->normalizeRole($values['raciResponsible'] ?? $values['responsible'] ?? []),
+            'accountable' => $this->normalizeRole($values['raciAccountable'] ?? $values['accountable'] ?? []),
+            'consulted' => $this->normalizeRole($values['raciConsulted'] ?? $values['consulted'] ?? []),
+            'informed' => $this->normalizeRole($values['raciInformed'] ?? $values['informed'] ?? []),
+        ];
+    }
+
+    private function normalizeRole(mixed $value): array
+    {
+        if (! is_array($value)) {
+            $value = $value === '' || $value === null ? [] : [$value];
+        }
+
+        $normalized = [];
+        foreach ($value as $candidate) {
+            $candidate = (int) $candidate;
+            if ($candidate > 0 && ! in_array($candidate, $normalized, true)) {
+                $normalized[] = $candidate;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function emptyAssignments(): array
+    {
+        return [
+            'responsible' => [],
+            'accountable' => [],
+            'consulted' => [],
+            'informed' => [],
+        ];
+    }
+
+    private function withSource(array $assignments, string $source): array
+    {
+        $assignments['_sources'] = [];
+        foreach (self::ROLE_KEYS as $roleKey) {
+            if (! empty($assignments[$roleKey])) {
+                $assignments['_sources'][$roleKey] = $source;
+            }
+        }
+
+        return $assignments;
+    }
+
+    private function overlay(array $base, array $overlay): array
+    {
+        foreach (self::ROLE_KEYS as $roleKey) {
+            if (! empty($overlay[$roleKey])) {
+                $base[$roleKey] = $overlay[$roleKey];
+                $base['_sources'][$roleKey] = $overlay['_sources'][$roleKey] ?? 'none';
+            } elseif (! isset($base['_sources'][$roleKey])) {
+                $base['_sources'][$roleKey] = 'none';
+            }
+        }
+
+        return $base;
+    }
+
+    private function isEmptyAssignments(array $assignments): bool
+    {
+        foreach (self::ROLE_KEYS as $roleKey) {
+            if (! empty($assignments[$roleKey])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function projectKey(int $projectId): string
+    {
+        return 'projectsettings.'.$projectId.'.raciAssignments';
+    }
+
+    private function milestoneKey(int $milestoneId): string
+    {
+        return 'milestonesettings.'.$milestoneId.'.raciAssignments';
+    }
+
+    private function ticketKey(int $ticketId): string
+    {
+        return 'ticketsettings.'.$ticketId.'.raciAssignments';
+    }
+
+    private function extractInt(array|object $entity, string $key): int
+    {
+        return (int) $this->extractValue($entity, $key);
+    }
+
+    private function extractValue(array|object $entity, string $key): mixed
+    {
+        if (is_array($entity)) {
+            return $entity[$key] ?? null;
+        }
+
+        return $entity->$key ?? null;
+    }
+}

--- a/app/Domain/Raci/Services/RaciDigests.php
+++ b/app/Domain/Raci/Services/RaciDigests.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Leantime\Domain\Raci\Services;
+
+use Leantime\Domain\Notifications\Models\Notification;
+use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
+
+class RaciDigests
+{
+    public function __construct(
+        private SettingRepository $settingsRepo,
+    ) {}
+
+    public function queueEntries(array $userIds, Notification $notification, string $cadence): void
+    {
+        foreach (array_values(array_unique(array_map('intval', $userIds))) as $userId) {
+            if ($userId <= 0 || $userId === (int) $notification->authorId) {
+                continue;
+            }
+
+            $key = 'usersettings.'.$userId.'.notificationDigests.pending';
+            $existing = $this->settingsRepo->getSetting($key, false);
+            $entries = [];
+
+            if (is_string($existing) && trim($existing) !== '') {
+                $decoded = json_decode($existing, true);
+                if (is_array($decoded)) {
+                    $entries = $decoded;
+                }
+            }
+
+            $entity = isset($notification->entity) ? $notification->entity : null;
+            $entry = [
+                'hash' => md5(implode('|', [
+                    $userId,
+                    $notification->module,
+                    $notification->action,
+                    is_array($entity) ? (string) ($entity['moduleId'] ?? $notification->projectId) : (string) $notification->projectId,
+                    (string) $notification->subject,
+                ])),
+                'cadence' => $cadence,
+                'module' => $notification->module,
+                'action' => $notification->action,
+                'projectId' => (int) $notification->projectId,
+                'subject' => (string) $notification->subject,
+                'message' => (string) $notification->message,
+                'url' => is_array($notification->url) ? ($notification->url['url'] ?? '') : '',
+                'queuedAt' => date('Y-m-d H:i:s'),
+                'authorId' => (int) $notification->authorId,
+            ];
+
+            $entries = array_values(array_filter($entries, static fn (array $existingEntry): bool => ($existingEntry['hash'] ?? '') !== $entry['hash']));
+            $entries[] = $entry;
+            $entries = array_slice($entries, -100);
+
+            $this->settingsRepo->saveSetting($key, json_encode($entries, JSON_THROW_ON_ERROR));
+        }
+    }
+}

--- a/app/Domain/Raci/Services/RaciNotificationRouting.php
+++ b/app/Domain/Raci/Services/RaciNotificationRouting.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Leantime\Domain\Raci\Services;
+
+use Leantime\Domain\Notifications\Models\Notification;
+use Leantime\Domain\Tickets\Repositories\Tickets as TicketRepository;
+
+class RaciNotificationRouting
+{
+    public function __construct(
+        private RaciAssignments $raciAssignments,
+        private TicketRepository $ticketRepository,
+    ) {}
+
+    public function resolveRecipients(Notification $notification): array
+    {
+        $assignments = $this->resolveAssignments($notification);
+
+        if ($assignments === null || ! $this->hasAssignments($assignments)) {
+            return [
+                'hasScopedAssignments' => false,
+                'cta' => [],
+                'info' => [],
+                'digest' => [],
+                'cadence' => $this->suggestDigestCadence($notification),
+            ];
+        }
+
+        return [
+            'hasScopedAssignments' => true,
+            'cta' => array_values(array_unique(array_merge(
+                array_map('intval', $assignments['responsible'] ?? []),
+                array_map('intval', $assignments['accountable'] ?? [])
+            ))),
+            'info' => array_values(array_unique(array_map('intval', $assignments['consulted'] ?? []))),
+            'digest' => array_values(array_unique(array_map('intval', $assignments['informed'] ?? []))),
+            'cadence' => $this->suggestDigestCadence($notification),
+        ];
+    }
+
+    public function suggestDigestCadence(Notification $notification): string
+    {
+        return match ($notification->action) {
+            'commented', 'status_changed' => 'daily',
+            'created', 'updated' => $notification->module === 'projects' ? 'weekly' : 'daily',
+            default => 'daily',
+        };
+    }
+
+    private function resolveAssignments(Notification $notification): ?array
+    {
+        return match ($notification->module) {
+            'projects' => $this->raciAssignments->getProjectAssignments((int) $notification->projectId),
+            'tickets' => $this->resolveTicketLikeAssignments($notification->entity),
+            'comments' => $this->resolveCommentAssignments($notification),
+            default => null,
+        };
+    }
+
+    private function resolveCommentAssignments(Notification $notification): ?array
+    {
+        $entity = $notification->entity;
+        if (is_array($entity) && ($entity['contextModule'] ?? '') === 'project') {
+            return $this->raciAssignments->getProjectAssignments((int) ($entity['contextId'] ?? $notification->projectId));
+        }
+
+        $contextId = is_array($entity) ? (int) ($entity['contextId'] ?? $entity['moduleId'] ?? 0) : 0;
+        if ($contextId <= 0) {
+            return null;
+        }
+
+        $ticket = $this->ticketRepository->getTicket($contextId);
+        if (! $ticket) {
+            return null;
+        }
+
+        return $this->resolveTicketLikeAssignments($ticket);
+    }
+
+    private function resolveTicketLikeAssignments(array|object|null $entity): ?array
+    {
+        if ($entity === null) {
+            return null;
+        }
+
+        $type = strtolower((string) $this->extract($entity, 'type'));
+        if ($type === 'milestone') {
+            return $this->raciAssignments->resolveForMilestone($entity);
+        }
+
+        return $this->raciAssignments->resolveForTicket($entity);
+    }
+
+    private function hasAssignments(array $assignments): bool
+    {
+        foreach (RaciAssignments::ROLE_KEYS as $roleKey) {
+            if (! empty($assignments[$roleKey])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function extract(array|object $entity, string $key): mixed
+    {
+        if (is_array($entity)) {
+            return $entity[$key] ?? null;
+        }
+
+        return $entity->$key ?? null;
+    }
+}

--- a/app/Domain/Tickets/Controllers/EditMilestone.php
+++ b/app/Domain/Tickets/Controllers/EditMilestone.php
@@ -10,6 +10,7 @@ use Leantime\Domain\Comments\Services\Comments as CommentService;
 use Leantime\Domain\Notifications\Models\Notification as NotificationModel;
 use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
+use Leantime\Domain\Raci\Services\RaciAssignments;
 use Leantime\Domain\Tickets\Models\Tickets as TicketModel;
 use Leantime\Domain\Tickets\Repositories\Tickets as TicketRepository;
 use Leantime\Domain\Tickets\Services\Tickets as TicketService;
@@ -25,6 +26,7 @@ class EditMilestone extends Controller
     private TicketRepository $ticketRepo;
 
     private ProjectRepository $projectRepo;
+    private RaciAssignments $raciAssignments;
 
     /**
      * init - initialize private variables
@@ -34,13 +36,15 @@ class EditMilestone extends Controller
         CommentService $commentsService,
         ProjectService $projectService,
         TicketRepository $ticketRepo,
-        ProjectRepository $projectRepo
+        ProjectRepository $projectRepo,
+        RaciAssignments $raciAssignments
     ) {
         $this->ticketService = $ticketService;
         $this->commentsService = $commentsService;
         $this->projectService = $projectService;
         $this->ticketRepo = $ticketRepo;
         $this->projectRepo = $projectRepo;
+        $this->raciAssignments = $raciAssignments;
     }
 
     /**
@@ -98,8 +102,14 @@ class EditMilestone extends Controller
 
         $allProjectMilestones = $this->ticketService->getAllMilestones(['sprint' => '', 'type' => 'milestone', 'currentProject' => session('currentProject')]);
         $this->tpl->assign('milestones', $allProjectMilestones);
-        $this->tpl->assign('users', $this->projectRepo->getUsersAssignedToProject(session('currentProject')));
+        $projectUsers = $this->projectRepo->getUsersAssignedToProject(session('currentProject'));
+        $this->tpl->assign('users', $projectUsers);
         $this->tpl->assign('milestone', $milestone);
+        $this->tpl->assign('milestoneRaci', isset($milestone->id) ? $this->raciAssignments->getMilestoneAssignments((int) $milestone->id) : []);
+        $this->tpl->assign('resolvedMilestoneRaci', $this->raciAssignments->toDisplayAssignments(
+            $this->raciAssignments->resolveForMilestone($milestone),
+            $projectUsers
+        ));
 
         return $this->tpl->displayPartial('tickets.milestoneDialog');
     }
@@ -155,6 +165,7 @@ class EditMilestone extends Controller
 
             if (isset($params['headline']) === true) {
                 if ($this->ticketService->quickUpdateMilestone($params)) {
+                    $this->raciAssignments->saveMilestoneAssignments((int) $params['id'], $params);
                     $this->tpl->setNotification($this->language->__('notification.milestone_edited_successfully'), 'success');
 
                     $subject = $this->language->__('email_notifications.milestone_update_subject');
@@ -188,6 +199,7 @@ class EditMilestone extends Controller
 
             if (is_numeric($result)) {
                 $params['id'] = $result;
+                $this->raciAssignments->saveMilestoneAssignments((int) $result, $params);
 
                 $this->tpl->setNotification($this->language->__('notification.milestone_created_successfully'), 'success');
 

--- a/app/Domain/Tickets/Controllers/ShowTicket.php
+++ b/app/Domain/Tickets/Controllers/ShowTicket.php
@@ -10,6 +10,7 @@ use Leantime\Core\Support\FromFormat;
 use Leantime\Domain\Comments\Services\Comments as CommentService;
 use Leantime\Domain\Files\Services\Files as FileService;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
+use Leantime\Domain\Raci\Services\RaciAssignments;
 use Leantime\Domain\Sprints\Services\Sprints as SprintService;
 use Leantime\Domain\Ticketdependencies\Services\Ticketdependencies as TicketdependencyService;
 use Leantime\Domain\Supportcenter\Services\GithubElevation;
@@ -38,6 +39,7 @@ class ShowTicket extends Controller
 
     private TicketdependencyService $ticketdependencyService;
     private GithubElevation $githubElevation;
+    private RaciAssignments $raciAssignments;
 
     public function init(
         ProjectService $projectService,
@@ -48,7 +50,8 @@ class ShowTicket extends Controller
         TimesheetService $timesheetService,
         UserService $userService,
         TicketdependencyService $ticketdependencyService,
-        GithubElevation $githubElevation
+        GithubElevation $githubElevation,
+        RaciAssignments $raciAssignments
     ): void {
         $this->projectService = $projectService;
         $this->ticketService = $ticketService;
@@ -59,6 +62,7 @@ class ShowTicket extends Controller
         $this->userService = $userService;
         $this->ticketdependencyService = $ticketdependencyService;
         $this->githubElevation = $githubElevation;
+        $this->raciAssignments = $raciAssignments;
 
         if (session()->exists('lastPage') === false) {
             session(['lastPage' => BASE_URL.'/tickets/showKanban']);
@@ -263,7 +267,13 @@ class ShowTicket extends Controller
         $this->tpl->assign('remainingHours', $this->timesheetService->getRemainingHours($ticket));
 
         $this->tpl->assign('userInfo', $this->userService->getUser(session('userdata.id')));
-        $this->tpl->assign('users', $this->projectService->getUsersAssignedToProject($ticket->projectId));
+        $projectUsers = $this->projectService->getUsersAssignedToProject($ticket->projectId);
+        $this->tpl->assign('users', $projectUsers);
+        $this->tpl->assign('ticketRaci', $this->raciAssignments->getTicketAssignments($id));
+        $this->tpl->assign('resolvedTicketRaci', $this->raciAssignments->toDisplayAssignments(
+            $this->raciAssignments->resolveForTicket($ticket),
+            $projectUsers
+        ));
 
         $projectData = $this->projectService->getProject($ticket->projectId);
         $this->tpl->assign('projectData', $projectData);

--- a/app/Domain/Tickets/Services/Tickets.php
+++ b/app/Domain/Tickets/Services/Tickets.php
@@ -20,6 +20,7 @@ use Leantime\Domain\Goalcanvas\Services\Goalcanvas;
 use Leantime\Domain\Notifications\Models\Notification as NotificationModel;
 use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
 use Leantime\Domain\Projects\Services\Projects as ProjectService;
+use Leantime\Domain\Raci\Services\RaciAssignments;
 use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
 use Leantime\Domain\Sprints\Services\Sprints as SprintService;
 use Leantime\Domain\Ticketdependencies\Services\Ticketdependencies as TicketdependencyService;
@@ -68,7 +69,8 @@ class Tickets
         private SprintService $sprintService,
         private TicketHistory $ticketHistoryRepo,
         private Goalcanvas $goalcanvasService,
-        private DateTimeHelper $dateTimeHelper
+        private DateTimeHelper $dateTimeHelper,
+        private RaciAssignments $raciAssignments
     ) {}
 
     /**
@@ -1858,6 +1860,10 @@ class Tickets
             'milestoneid' => isset($params['milestone']) ? (int) $params['milestone'] : '',
             'dependingTicketId' => isset($params['dependingTicketId']) ? (int) $params['dependingTicketId'] : '',
             'sortIndex' => $params['sortIndex'] ?? '',
+            'raciResponsible' => $params['raciResponsible'] ?? [],
+            'raciAccountable' => $params['raciAccountable'] ?? [],
+            'raciConsulted' => $params['raciConsulted'] ?? [],
+            'raciInformed' => $params['raciInformed'] ?? [],
         ];
 
         if ($values['headline'] == '') {
@@ -1872,6 +1878,7 @@ class Tickets
 
         if ($result > 0) {
             $values['id'] = $result;
+            $this->raciAssignments->saveTicketAssignments((int) $result, $params);
             $actual_link = BASE_URL.'/dashboard/home#/tickets/showTicket/'.$result;
             $message = sprintf($this->language->__('email_notifications.new_todo_message'), session('userdata.name'), strip_tags($params['headline']));
             $subject = $this->language->__('email_notifications.new_todo_subject');
@@ -2015,6 +2022,10 @@ class Tickets
             'dependingTicketId' => $values['dependingTicketId'] ?? '',
             'milestoneid' => $values['milestoneid'] ?? '',
             'collaborators' => $values['collaborators'] ?? [],
+            'raciResponsible' => $values['raciResponsible'] ?? [],
+            'raciAccountable' => $values['raciAccountable'] ?? [],
+            'raciConsulted' => $values['raciConsulted'] ?? [],
+            'raciInformed' => $values['raciInformed'] ?? [],
         ];
 
         if (! $this->projectService->isUserAssignedToProject(session('userdata.id'), $values['projectId'])) {
@@ -2033,6 +2044,7 @@ class Tickets
 
             if ($addTicketResponse !== false) {
                 $values['id'] = $addTicketResponse;
+                $this->raciAssignments->saveTicketAssignments((int) $addTicketResponse, $values);
                 $subject = sprintf($this->language->__('email_notifications.new_todo_subject'), $addTicketResponse, strip_tags($values['headline']));
                 $actual_link = BASE_URL.'/dashboard/home#/tickets/showTicket/'.$addTicketResponse;
                 $message = sprintf($this->language->__('email_notifications.new_todo_message'), session('userdata.name'), strip_tags($values['headline']));
@@ -2130,6 +2142,10 @@ class Tickets
             'collaborators' => $values['collaborators'] ?? [],
             'dependencyTicketIds' => $values['dependencyTicketIds'] ?? [],
             'autoRescheduleDependencies' => (int) ($values['autoRescheduleDependencies'] ?? 0),
+            'raciResponsible' => $values['raciResponsible'] ?? [],
+            'raciAccountable' => $values['raciAccountable'] ?? [],
+            'raciConsulted' => $values['raciConsulted'] ?? [],
+            'raciInformed' => $values['raciInformed'] ?? [],
         ];
 
         if ($values['projectId'] === null || $values['projectId'] === '' || $values['projectId'] === false) {
@@ -2164,6 +2180,7 @@ class Tickets
 
         // Update Ticket
         if ($this->ticketRepository->updateTicket($values, $values['id']) === true) {
+            $this->raciAssignments->saveTicketAssignments((int) $values['id'], $values);
             $ticketdependencyService->syncDependencies(
                 (int) $values['id'],
                 $values['dependencyTicketIds'],
@@ -2388,9 +2405,11 @@ class Tickets
 
         if ($subtaskId == 'new' || $subtaskId == '') {
             // New Ticket
-            if (! $this->ticketRepository->addTicket($values)) {
+            $newSubtaskId = $this->ticketRepository->addTicket($values);
+            if (! $newSubtaskId) {
                 return false;
             }
+            $this->raciAssignments->saveTicketAssignments((int) $newSubtaskId, $values);
 
             self::dispatchEvent('ticket_created');
 
@@ -2400,6 +2419,7 @@ class Tickets
             if (! $this->ticketRepository->updateTicket($values, $subtaskId)) {
                 return false;
             }
+            $this->raciAssignments->saveTicketAssignments((int) $subtaskId, $values);
 
             self::dispatchEvent('ticket_updated');
         }

--- a/app/Domain/Tickets/Templates/milestoneDialog.tpl.php
+++ b/app/Domain/Tickets/Templates/milestoneDialog.tpl.php
@@ -5,6 +5,13 @@ foreach ($__data as $var => $val) {
 $currentMilestone = $tpl->get('milestone');
 $milestones = $tpl->get('milestones');
 $statusLabels = $tpl->get('statusLabels');
+$milestoneRaci = $tpl->get('milestoneRaci') ?? [];
+$resolvedMilestoneRaci = $tpl->get('resolvedMilestoneRaci') ?? [];
+$raciSourceLabels = [
+    'milestone' => 'This milestone',
+    'project' => 'Project',
+    'none' => 'Not set',
+];
 ?>
 
 <script type="text/javascript">
@@ -98,6 +105,34 @@ $statusLabels = $tpl->get('statusLabels');
 
         <?php } ?>
     </select>
+
+    <label style="margin-top: 15px;">RACI Assignments</label>
+    <div class="small muted" style="margin-bottom:8px;">Leave milestone fields empty to inherit from the project.</div>
+    <?php foreach ([
+        'Responsible' => 'responsible',
+        'Accountable' => 'accountable',
+        'Consulted' => 'consulted',
+        'Informed' => 'informed',
+    ] as $roleLabel => $roleKey) { ?>
+        <label><?= $roleLabel ?></label>
+        <select name="raci<?= $roleLabel ?>[]" class="user-select span11" multiple>
+            <?php foreach ($tpl->get('users') as $userRow) { ?>
+                <option value="<?php echo $userRow['id']; ?>"
+                    <?php if (in_array((int) $userRow['id'], array_map('intval', (array) ($milestoneRaci[$roleKey] ?? [])), true)) {
+                        echo " selected='selected' ";
+                    } ?>
+                >
+                    <?php echo $tpl->escape($userRow['firstname']).' '.$tpl->escape($userRow['lastname']); ?>
+                </option>
+            <?php } ?>
+        </select>
+        <?php $effectiveRole = $resolvedMilestoneRaci[$roleKey] ?? ['names' => [], 'source' => 'none']; ?>
+        <div class="small muted" style="margin: 4px 0 8px 0;">
+            Effective:
+            <?php echo ! empty($effectiveRole['names']) ? $tpl->escape(implode(', ', $effectiveRole['names'])) : 'None'; ?>
+            (<?php echo $tpl->escape($raciSourceLabels[$effectiveRole['source'] ?? 'none'] ?? 'Not set'); ?>)
+        </div>
+    <?php } ?>
 
     <label><?= $tpl->__('label.color'); ?></label>
     <input type="text" name="tags" autocomplete="off" value="<?php echo $currentMilestone->tags?>" placeholder="<?= $tpl->__('input.placeholders.pick_a_color'); ?>" class="simpleColorPicker"/><br />

--- a/app/Domain/Tickets/Templates/submodules/ticketDetails.sub.php
+++ b/app/Domain/Tickets/Templates/submodules/ticketDetails.sub.php
@@ -8,7 +8,16 @@ $statusLabels = $tpl->get('statusLabels');
 $ticketTypes = $tpl->get('ticketTypes');
 $dependencyTicketIds = $tpl->get('dependencyTicketIds') ?? [];
 $dependencyTickets = $tpl->get('dependencyTickets') ?? [];
+$ticketRaci = $tpl->get('ticketRaci') ?? [];
+$resolvedTicketRaci = $tpl->get('resolvedTicketRaci') ?? [];
 $dependencyScheduleMap = [];
+$raciSourceLabels = [
+    'task' => 'This task',
+    'parent_task' => 'Parent task',
+    'milestone' => 'Milestone',
+    'project' => 'Project',
+    'none' => 'Not set',
+];
 
 foreach ($dependencyTickets as $dependencyTicket) {
     $dependencyId = (int) ($dependencyTicket['id'] ?? 0);
@@ -138,6 +147,47 @@ foreach ($dependencyTickets as $dependencyTicket) {
                             <?php } ?>
                         </select>
                     </div>
+                </div>
+
+                <div class="form-group">
+                    <h5 class="widgettitle title-light" style="margin: 20px 0 10px 0;">
+                        <i class="fa fa-users"></i> RACI Assignments
+                    </h5>
+                    <div class="small muted" style="margin-bottom:10px;">
+                        Leave task fields empty to inherit from milestone or project. Subtasks inherit from their parent task before milestone/project defaults.
+                    </div>
+
+                    <?php foreach ([
+                        'Responsible' => 'responsible',
+                        'Accountable' => 'accountable',
+                        'Consulted' => 'consulted',
+                        'Informed' => 'informed',
+                    ] as $roleLabel => $roleKey) { ?>
+                        <div class="form-group tw-flex tw-w-3/5">
+                            <label class="control-label tw-mx-m tw-w-[100px]"><?php echo $roleLabel; ?></label>
+                            <div class="" style="min-width: 220px;">
+                                <select name="raci<?php echo $roleLabel; ?>[]" class="user-select tw-mr-sm" multiple style="width: 220px;">
+                                    <?php foreach ($tpl->get('users') as $userRow) { ?>
+                                        <option value="<?php echo $userRow['id']; ?>"
+                                            <?php if (in_array((int) $userRow['id'], array_map('intval', (array) ($ticketRaci[$roleKey] ?? [])), true)) {
+                                                echo "selected='selected'";
+                                            } ?>
+                                        >
+                                            <?php echo $tpl->escape($userRow['firstname'].' '.$userRow['lastname']); ?>
+                                        </option>
+                                    <?php } ?>
+                                </select>
+                                <?php $effectiveRole = $resolvedTicketRaci[$roleKey] ?? ['names' => [], 'source' => 'none']; ?>
+                                <div class="small muted" style="margin-top:4px;">
+                                    Effective:
+                                    <?php echo ! empty($effectiveRole['names']) ? $tpl->escape(implode(', ', $effectiveRole['names'])) : 'None'; ?>
+                                    <span>
+                                        (<?php echo $tpl->escape($raciSourceLabels[$effectiveRole['source'] ?? 'none'] ?? 'Not set'); ?>)
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    <?php } ?>
                 </div>
 
                 <!-- Due Date -->

--- a/tests/Unit/app/Domain/Raci/Services/RaciAssignmentsTest.php
+++ b/tests/Unit/app/Domain/Raci/Services/RaciAssignmentsTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Unit\app\Domain\Raci\Services;
+
+require_once __DIR__.'/../../../../../../app/Domain/Setting/Services/SettingCache.php';
+require_once __DIR__.'/../../../../../../app/Domain/Setting/Repositories/Setting.php';
+require_once __DIR__.'/../../../../../../app/Domain/Tickets/Repositories/Tickets.php';
+require_once __DIR__.'/../../../../../../app/Domain/Raci/Services/RaciAssignments.php';
+
+use Leantime\Domain\Raci\Services\RaciAssignments;
+use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
+use Leantime\Domain\Tickets\Repositories\Tickets as TicketRepository;
+use Unit\TestCase;
+
+class RaciAssignmentsTest extends TestCase
+{
+    public function test_it_normalizes_and_saves_project_assignments(): void
+    {
+        $settings = $this->createMock(SettingRepository::class);
+        $tickets = $this->createMock(TicketRepository::class);
+
+        $settings->expects($this->once())
+            ->method('saveSetting')
+            ->with(
+                'projectsettings.27.raciAssignments',
+                json_encode([
+                    'responsible' => [5, 8],
+                    'accountable' => [11],
+                    'consulted' => [],
+                    'informed' => [14],
+                ], JSON_THROW_ON_ERROR)
+            );
+
+        $service = new RaciAssignments($settings, $tickets);
+        $service->saveProjectAssignments(27, [
+            'raciResponsible' => ['5', '8', '8'],
+            'raciAccountable' => ['11'],
+            'raciInformed' => ['14'],
+        ]);
+    }
+
+    public function test_ticket_resolution_prefers_task_then_parent_then_milestone_then_project(): void
+    {
+        $settings = $this->createMock(SettingRepository::class);
+        $tickets = $this->createMock(TicketRepository::class);
+
+        $settings->method('getSetting')->willReturnMap([
+            ['projectsettings.9.raciAssignments', false, json_encode([
+                'responsible' => [1],
+                'accountable' => [],
+                'consulted' => [],
+                'informed' => [7],
+            ], JSON_THROW_ON_ERROR)],
+            ['milestonesettings.22.raciAssignments', false, json_encode([
+                'responsible' => [2],
+                'accountable' => [3],
+                'consulted' => [],
+                'informed' => [],
+            ], JSON_THROW_ON_ERROR)],
+            ['ticketsettings.14.raciAssignments', false, json_encode([
+                'responsible' => [],
+                'accountable' => [],
+                'consulted' => [4],
+                'informed' => [],
+            ], JSON_THROW_ON_ERROR)],
+            ['ticketsettings.15.raciAssignments', false, json_encode([
+                'responsible' => [5],
+                'accountable' => [],
+                'consulted' => [],
+                'informed' => [6],
+            ], JSON_THROW_ON_ERROR)],
+        ]);
+
+        $service = new RaciAssignments($settings, $tickets);
+
+        $resolved = $service->resolveForTicket((object) [
+            'id' => 15,
+            'type' => 'subtask',
+            'projectId' => 9,
+            'milestoneid' => 22,
+            'dependingTicketId' => 14,
+        ]);
+
+        $this->assertSame([5], $resolved['responsible']);
+        $this->assertSame([3], $resolved['accountable']);
+        $this->assertSame([4], $resolved['consulted']);
+        $this->assertSame([6], $resolved['informed']);
+        $this->assertSame('task', $resolved['_sources']['responsible']);
+        $this->assertSame('milestone', $resolved['_sources']['accountable']);
+        $this->assertSame('parent_task', $resolved['_sources']['consulted']);
+        $this->assertSame('task', $resolved['_sources']['informed']);
+    }
+
+    public function test_display_assignments_include_names_and_sources(): void
+    {
+        $settings = $this->createMock(SettingRepository::class);
+        $tickets = $this->createMock(TicketRepository::class);
+        $service = new RaciAssignments($settings, $tickets);
+
+        $display = $service->toDisplayAssignments([
+            'responsible' => [2],
+            'accountable' => [],
+            'consulted' => [3, 4],
+            'informed' => [],
+            '_sources' => [
+                'responsible' => 'task',
+                'consulted' => 'project',
+            ],
+        ], [
+            ['id' => 2, 'firstname' => 'Devon', 'lastname' => 'Scott'],
+            ['id' => 3, 'firstname' => 'Avery', 'lastname' => 'Lane'],
+            ['id' => 4, 'firstname' => 'Morgan', 'lastname' => 'Reed'],
+        ]);
+
+        $this->assertSame(['Devon Scott'], $display['responsible']['names']);
+        $this->assertSame('task', $display['responsible']['source']);
+        $this->assertSame(['Avery Lane', 'Morgan Reed'], $display['consulted']['names']);
+        $this->assertSame('project', $display['consulted']['source']);
+    }
+}

--- a/tests/Unit/app/Domain/Raci/Services/RaciDigestsTest.php
+++ b/tests/Unit/app/Domain/Raci/Services/RaciDigestsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Unit\app\Domain\Raci\Services;
+
+require_once __DIR__.'/../../../../../../app/Domain/Notifications/Models/Notification.php';
+require_once __DIR__.'/../../../../../../app/Domain/Setting/Repositories/Setting.php';
+require_once __DIR__.'/../../../../../../app/Domain/Setting/Services/SettingCache.php';
+require_once __DIR__.'/../../../../../../app/Domain/Raci/Services/RaciDigests.php';
+
+use Leantime\Domain\Notifications\Models\Notification;
+use Leantime\Domain\Raci\Services\RaciDigests;
+use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
+use Unit\TestCase;
+
+class RaciDigestsTest extends TestCase
+{
+    public function test_it_stores_digest_entries_for_informed_users(): void
+    {
+        $settings = $this->createMock(SettingRepository::class);
+        $settings->method('getSetting')->willReturn(false);
+        $settings->expects($this->once())
+            ->method('saveSetting')
+            ->with(
+                'usersettings.12.notificationDigests.pending',
+                $this->callback(function (string $json): bool {
+                    $decoded = json_decode($json, true);
+
+                    return is_array($decoded)
+                        && count($decoded) === 1
+                        && ($decoded[0]['cadence'] ?? '') === 'weekly'
+                        && ($decoded[0]['module'] ?? '') === 'projects';
+                })
+            );
+
+        $notification = new Notification;
+        $notification->module = 'projects';
+        $notification->action = 'updated';
+        $notification->projectId = 27;
+        $notification->subject = 'Project updated';
+        $notification->message = 'A project update happened.';
+        $notification->url = ['url' => 'https://example.test/project/27', 'text' => 'Open'];
+        $notification->authorId = 4;
+
+        $service = new RaciDigests($settings);
+        $service->queueEntries([12], $notification, 'weekly');
+    }
+}

--- a/tests/Unit/app/Domain/Raci/Services/RaciNotificationRoutingTest.php
+++ b/tests/Unit/app/Domain/Raci/Services/RaciNotificationRoutingTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Unit\app\Domain\Raci\Services;
+
+require_once __DIR__.'/../../../../../../app/Domain/Notifications/Models/Notification.php';
+require_once __DIR__.'/../../../../../../app/Domain/Raci/Services/RaciAssignments.php';
+require_once __DIR__.'/../../../../../../app/Domain/Raci/Services/RaciNotificationRouting.php';
+require_once __DIR__.'/../../../../../../app/Domain/Tickets/Repositories/Tickets.php';
+
+use Leantime\Domain\Notifications\Models\Notification;
+use Leantime\Domain\Raci\Services\RaciAssignments;
+use Leantime\Domain\Raci\Services\RaciNotificationRouting;
+use Leantime\Domain\Tickets\Repositories\Tickets as TicketRepository;
+use Unit\TestCase;
+
+class RaciNotificationRoutingTest extends TestCase
+{
+    public function test_it_routes_responsible_and_accountable_to_cta_consulted_to_info_and_informed_to_digest(): void
+    {
+        $assignments = $this->createMock(RaciAssignments::class);
+        $tickets = $this->createMock(TicketRepository::class);
+
+        $assignments->method('resolveForTicket')->willReturn([
+            'responsible' => [5],
+            'accountable' => [6],
+            'consulted' => [7],
+            'informed' => [8],
+        ]);
+
+        $notification = new Notification;
+        $notification->module = 'tickets';
+        $notification->action = 'updated';
+        $notification->entity = ['id' => 42, 'type' => 'task', 'projectId' => 11, 'milestoneid' => 0, 'dependingTicketId' => 0];
+
+        $routing = new RaciNotificationRouting($assignments, $tickets);
+        $result = $routing->resolveRecipients($notification);
+
+        $this->assertTrue($result['hasScopedAssignments']);
+        $this->assertSame([5, 6], $result['cta']);
+        $this->assertSame([7], $result['info']);
+        $this->assertSame([8], $result['digest']);
+        $this->assertSame('daily', $result['cadence']);
+    }
+
+    public function test_it_uses_weekly_digest_for_project_updates(): void
+    {
+        $assignments = $this->createMock(RaciAssignments::class);
+        $tickets = $this->createMock(TicketRepository::class);
+        $assignments->method('getProjectAssignments')->willReturn([
+            'responsible' => [],
+            'accountable' => [],
+            'consulted' => [],
+            'informed' => [9],
+        ]);
+
+        $notification = new Notification;
+        $notification->module = 'projects';
+        $notification->action = 'updated';
+        $notification->projectId = 27;
+
+        $routing = new RaciNotificationRouting($assignments, $tickets);
+        $result = $routing->resolveRecipients($notification);
+
+        $this->assertSame('weekly', $result['cadence']);
+        $this->assertSame([9], $result['digest']);
+    }
+}


### PR DESCRIPTION
Intent summary
Add hierarchical RACI assignments across projects, milestones, tasks, and subtasks, with inherited effective-role resolution and role-aware notification routing.

User stories / acceptance criteria
- Users can assign Responsible, Accountable, Consulted, and Informed roles at the project level.
- Users can assign Responsible, Accountable, Consulted, and Informed roles at the milestone level.
- Users can assign Responsible, Accountable, Consulted, and Informed roles at the task level.
- Subtasks inherit empty RACI roles from their parent task.
- Tasks inherit empty RACI roles from their milestone.
- Milestones inherit empty RACI roles from their project.
- Responsible and Accountable users receive immediate CTA-style notifications.
- Consulted users receive immediate informational notifications without CTA links.
- Informed users are queued into pending digests instead of receiving immediate alerts.
- Current notification segmentation remains compatible.

Key files changed
- `app/Domain/Raci/Services/RaciAssignments.php`
- `app/Domain/Raci/Services/RaciNotificationRouting.php`
- `app/Domain/Raci/Services/RaciDigests.php`
- `app/Domain/Projects/Services/Projects.php`
- `app/Domain/Comments/Services/Comments.php`
- `app/Domain/Notifications/Listeners/NotifyProjectUsers.php`
- `app/Domain/Projects/Controllers/ShowProject.php`
- `app/Domain/Tickets/Controllers/EditMilestone.php`
- `app/Domain/Tickets/Controllers/ShowTicket.php`
- `app/Domain/Tickets/Services/Tickets.php`
- `app/Domain/Projects/Templates/submodules/projectDetails.sub.php`
- `app/Domain/Tickets/Templates/milestoneDialog.tpl.php`
- `app/Domain/Tickets/Templates/submodules/ticketDetails.sub.php`
- `tests/Unit/app/Domain/Raci/Services/RaciAssignmentsTest.php`
- `tests/Unit/app/Domain/Raci/Services/RaciNotificationRoutingTest.php`
- `tests/Unit/app/Domain/Raci/Services/RaciDigestsTest.php`

How to test
- `php ..\\..\\vendor\\bin\\codecept run Unit tests\\Unit\\app\\Domain\\Raci\\Services\\RaciAssignmentsTest.php`
- `php ..\\..\\vendor\\bin\\codecept run Unit tests\\Unit\\app\\Domain\\Raci\\Services\\RaciNotificationRoutingTest.php`
- `php ..\\..\\vendor\\bin\\codecept run Unit tests\\Unit\\app\\Domain\\Raci\\Services\\RaciDigestsTest.php`

QA checklist
- Project settings show RACI defaults and save correctly.
- Milestone modal shows milestone RACI fields and effective inherited roles.
- Ticket modal shows task RACI fields and effective inherited roles.
- Subtasks inherit from their parent task when their own fields are empty.
- Tasks inherit from milestones when task-level fields are empty.
- Milestones inherit from projects when milestone-level fields are empty.
- Responsible and Accountable recipients get immediate CTA-bearing notifications.
- Consulted recipients get immediate notifications without CTA links.
- Informed recipients do not get immediate notifications and instead appear in pending digest settings.

Approval conditions
- Staging QA confirms inheritance works across project -> milestone -> task -> subtask.
- Staging QA confirms the immediate-vs-digest notification split works as specified.
- No regression in existing ticket, milestone, or project save flows.
