### PR TITLE
Hotfix: fix support rich text image hosts

### DIFF
--- a/app/Core/UI/Template.php
+++ b/app/Core/UI/Template.php
@@ -727,6 +727,7 @@ class Template
     public function escapeMinimal(?string $content): string
     {
         $content = $this->convertRelativePaths($content);
+        $content = $this->normalizeLocalFilesGetUrls($content);
         $config = [
             'safe' => 1,
             'style_pass' => 1,
@@ -878,11 +879,68 @@ class Template
     public function patchDownloadUrlToFilenameOrAwsUrl(string $textHtml): string
     {
         $patchedTextHtml = $this->convertRelativePaths($textHtml);
-
-        // TO DO: Replace local files/get
-        $patchedTextHtml = $patchedTextHtml;
+        $patchedTextHtml = $this->normalizeLocalFilesGetUrls($patchedTextHtml);
 
         return $patchedTextHtml;
+    }
+
+    private function normalizeLocalFilesGetUrls(?string $content): string
+    {
+        if ($content === null || $content === '') {
+            return $content ?? '';
+        }
+
+        $baseUrl = rtrim((string) BASE_URL, '/');
+
+        $normalized = preg_replace_callback(
+            '/\b(?P<attr>href|src)\s*=\s*(?P<quote>[\'"])(?P<url>[^\'"]+)(?P=quote)/i',
+            function (array $matches) use ($baseUrl) {
+                $decodedUrl = html_entity_decode($matches['url'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+                if (! str_contains($decodedUrl, '/files/get?')) {
+                    return $matches[0];
+                }
+
+                $parts = parse_url($decodedUrl);
+
+                if ($parts === false) {
+                    return $matches[0];
+                }
+
+                $path = $parts['path'] ?? '';
+                if (! in_array($path, ['/files/get', 'files/get'], true)) {
+                    return $matches[0];
+                }
+
+                parse_str($parts['query'] ?? '', $queryParams);
+                if (
+                    ! isset($queryParams['encName'])
+                    || ! isset($queryParams['ext'])
+                    || ! isset($queryParams['realName'])
+                ) {
+                    return $matches[0];
+                }
+
+                $rewrittenUrl = $baseUrl.'/files/get';
+                $queryString = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+                if ($queryString !== '') {
+                    $rewrittenUrl .= '?'.$queryString;
+                }
+
+                if (isset($parts['fragment']) && $parts['fragment'] !== '') {
+                    $rewrittenUrl .= '#'.$parts['fragment'];
+                }
+
+                return $matches['attr']
+                    .'='
+                    .$matches['quote']
+                    .htmlspecialchars($rewrittenUrl, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+                    .$matches['quote'];
+            },
+            $content
+        );
+
+        return $normalized ?? $content;
     }
 
     /**

--- a/tests/Unit/app/Core/UI/TemplateTest.php
+++ b/tests/Unit/app/Core/UI/TemplateTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Unit\app\Core\UI;
+
+use Leantime\Core\UI\Template;
+use PHPUnit\Framework\TestCase;
+
+class TemplateTest extends TestCase
+{
+    private Template $template;
+
+    protected function setUp(): void
+    {
+        if (! defined('BASE_URL')) {
+            define('BASE_URL', 'http://localhost');
+        }
+
+        $reflection = new \ReflectionClass(Template::class);
+        $this->template = $reflection->newInstanceWithoutConstructor();
+    }
+
+    public function test_escape_minimal_rewrites_local_files_get_urls_to_current_base_url(): void
+    {
+        $content = '<p>Image</p><img src="https://support.example.com/files/get?module=project&amp;encName=abc123&amp;ext=png&amp;realName=Example%20Image.png" alt="Example" />';
+
+        $result = $this->template->escapeMinimal($content);
+
+        $this->assertStringContainsString(
+            'src="http://localhost/files/get?module=project&amp;encName=abc123&amp;ext=png&amp;realName=Example%20Image.png"',
+            $result
+        );
+    }
+
+    public function test_escape_minimal_leaves_external_images_untouched(): void
+    {
+        $content = '<img src="https://cdn.example.com/images/example.png" alt="Example" />';
+
+        $result = $this->template->escapeMinimal($content);
+
+        $this->assertStringContainsString(
+            'src="https://cdn.example.com/images/example.png"',
+            $result
+        );
+    }
+}


### PR DESCRIPTION
## Intent summary
Fix support ticket rich-text rendering so uploaded images using stored Leantime `/files/get` URLs resolve against the current app host instead of the original support-domain host.

## User stories / acceptance criteria
- As a support agent viewing a ticket in Leantime, images embedded through the rich text editor render instead of showing as broken when the stored HTML references another Leantime host.
- As a support portal user viewing ticket content or comments, Leantime-hosted rich-text images resolve on the current host.
- As a user referencing external image URLs, those links remain unchanged.

## Key files changed
- `app/Core/UI/Template.php`
- `tests/Unit/app/Core/UI/TemplateTest.php`

## How to test
- `php -l app/Core/UI/Template.php`
- `php -l tests/Unit/app/Core/UI/TemplateTest.php`
- `vendor/bin/phpunit tests/Unit/app/Core/UI/TemplateTest.php`
- Open a support ticket/comment containing an `<img src="https://support.<domain>/files/get?...">` HTML fragment in Leantime.
- Confirm the rendered HTML points to the current Leantime host and the image loads.
- Confirm a normal external image URL remains unchanged.

## QA checklist
- [ ] Support-center ticket descriptions render uploaded images when the stored HTML uses another Leantime host.
- [ ] Support-center comments render uploaded images under the current host.
- [ ] Support-portal ticket descriptions/comments render the same content correctly.
- [ ] External image URLs are not rewritten.

## Approval conditions
- QA verifies the reported broken-image case is resolved in the main panel.
- QA verifies no regression for other rich-text image rendering surfaces.
- Unit test coverage for the URL normalization path remains green.

## Tests run
- `php -l app/Core/UI/Template.php`
- `php -l tests/Unit/app/Core/UI/TemplateTest.php`
- `vendor/bin/phpunit tests/Unit/app/Core/UI/TemplateTest.php`