### PR TITLE
Resolve GitHub elevation attachments to direct file URLs

### DIFF
--- a/app/Domain/Files/Repositories/Files.php
+++ b/app/Domain/Files/Repositories/Files.php
@@ -60,6 +60,26 @@ class Files
         return $result ? (array) $result : false;
     }
 
+    public function findFileByEncodedName(string $encName, string $extension): array|false
+    {
+        $result = $this->db->table('zp_file as file')
+            ->select(
+                'file.id',
+                'file.extension',
+                'file.realName',
+                'file.encName',
+                'file.date',
+                'file.module',
+                'file.moduleId',
+                'file.userId'
+            )
+            ->where('file.encName', $encName)
+            ->where('file.extension', $extension)
+            ->first();
+
+        return $result ? (array) $result : false;
+    }
+
     public function getFiles(int $userId = 0): false|array
     {
         $query = $this->db->table('zp_file as file')

--- a/app/Domain/Supportcenter/Services/GithubElevation.php
+++ b/app/Domain/Supportcenter/Services/GithubElevation.php
@@ -3,13 +3,33 @@
 namespace Leantime\Domain\Supportcenter\Services;
 
 use Illuminate\Support\Facades\Http;
+use Leantime\Core\Files\FileManager;
+use Leantime\Domain\Files\Repositories\Files as FileRepository;
 use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
 
 class GithubElevation
 {
     public function __construct(
         private SettingRepository $settingRepository,
+        private FileRepository $fileRepository,
+        private FileManager $fileManager,
     ) {}
+
+    public function getDefaultGithubTitle(object $ticket): string
+    {
+        return trim((string) ($ticket->headline ?? ''));
+    }
+
+    public function getDefaultGithubSummary(object $ticket): string
+    {
+        $description = trim((string) ($ticket->description ?? ''));
+
+        if ($description === '') {
+            return '';
+        }
+
+        return $this->convertHtmlToMarkdown($description);
+    }
 
     public function getTicketGithubIssue(int $ticketId): array|false
     {
@@ -61,6 +81,14 @@ class GithubElevation
         $summary = trim((string) ($payload['githubSummary'] ?? ''));
         $reproduction = trim((string) ($payload['githubReproduction'] ?? ''));
         $impact = trim((string) ($payload['githubImpact'] ?? ''));
+
+        if ($title === '') {
+            $title = $this->getDefaultGithubTitle($ticket);
+        }
+
+        if ($summary === '') {
+            $summary = $this->getDefaultGithubSummary($ticket);
+        }
 
         if ($title === '' || $summary === '') {
             return ['ok' => false, 'message' => 'GitHub title and technical summary are required.'];
@@ -166,6 +194,190 @@ class GithubElevation
         $parts[] = (string) ($ticket->headline ?? '');
 
         return implode("\n", $parts);
+    }
+
+    private function convertHtmlToMarkdown(string $html): string
+    {
+        $html = $this->normalizeLocalFilesGetUrls($html);
+        $html = html_entity_decode($html, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        $html = preg_replace_callback('/<img\b[^>]*>/i', function (array $matches) {
+            $tag = $matches[0];
+            $src = $this->extractAttribute($tag, 'src');
+
+            if ($src === '') {
+                return '';
+            }
+
+            $resolvedSrc = $this->resolveDirectFileUrl($src);
+            $alt = $this->extractAttribute($tag, 'alt');
+            $label = $alt !== '' ? $alt : 'Image';
+
+            if ($resolvedSrc === false) {
+                return "\n[$label]($src)\n";
+            }
+
+            return "\n![$label]($resolvedSrc)\n";
+        }, $html) ?? $html;
+
+        $html = preg_replace_callback('/<a\b[^>]*href=["\']([^"\']+)["\'][^>]*>(.*?)<\/a>/is', function (array $matches) {
+            $url = trim($matches[1]);
+            $resolvedUrl = $this->resolveDirectFileUrl($url);
+            $text = trim($this->convertHtmlToPlainText($matches[2]));
+
+            if ($url === '') {
+                return $text;
+            }
+
+            $finalUrl = $resolvedUrl !== false ? $resolvedUrl : $url;
+
+            if ($text === '' || $text === $finalUrl) {
+                return $finalUrl;
+            }
+
+            return "[$text]($finalUrl)";
+        }, $html) ?? $html;
+
+        $html = preg_replace('/<li\b[^>]*>/i', "\n- ", $html) ?? $html;
+        $html = preg_replace('/<(br\s*\/?|\/p|\/div|\/li|\/ul|\/ol|\/h[1-6]|\/tr)>/i', "\n", $html) ?? $html;
+
+        $markdown = strip_tags($html);
+        $markdown = preg_replace("/\r\n?/", "\n", $markdown) ?? $markdown;
+        $markdown = preg_replace("/[ \t]+\n/", "\n", $markdown) ?? $markdown;
+        $markdown = preg_replace("/\n{3,}/", "\n\n", $markdown) ?? $markdown;
+
+        return trim($markdown);
+    }
+
+    private function convertHtmlToPlainText(string $html): string
+    {
+        $text = html_entity_decode(strip_tags($html), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $text = preg_replace("/\s+/", ' ', $text) ?? $text;
+
+        return trim($text);
+    }
+
+    private function extractAttribute(string $tag, string $attribute): string
+    {
+        if (! preg_match('/\b'.preg_quote($attribute, '/').'\s*=\s*["\']([^"\']*)["\']/i', $tag, $matches)) {
+            return '';
+        }
+
+        return trim(html_entity_decode($matches[1], ENT_QUOTES | ENT_HTML5, 'UTF-8'));
+    }
+
+    private function normalizeLocalFilesGetUrls(string $content): string
+    {
+        $baseUrl = rtrim((string) BASE_URL, '/');
+
+        $normalized = preg_replace_callback(
+            '/\b(?P<attr>href|src)\s*=\s*(?P<quote>[\'"])(?P<url>[^\'"]+)(?P=quote)/i',
+            function (array $matches) use ($baseUrl) {
+                $decodedUrl = html_entity_decode($matches['url'], ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+                if (! str_contains($decodedUrl, '/files/get?')) {
+                    return $matches[0];
+                }
+
+                $parts = parse_url($decodedUrl);
+
+                if ($parts === false) {
+                    return $matches[0];
+                }
+
+                $path = $parts['path'] ?? '';
+                if (! in_array($path, ['/files/get', 'files/get'], true)) {
+                    return $matches[0];
+                }
+
+                parse_str($parts['query'] ?? '', $queryParams);
+                if (
+                    ! isset($queryParams['encName'])
+                    || ! isset($queryParams['ext'])
+                    || ! isset($queryParams['realName'])
+                ) {
+                    return $matches[0];
+                }
+
+                $rewrittenUrl = $baseUrl.'/files/get';
+                $queryString = http_build_query($queryParams, '', '&', PHP_QUERY_RFC3986);
+                if ($queryString !== '') {
+                    $rewrittenUrl .= '?'.$queryString;
+                }
+
+                if (isset($parts['fragment']) && $parts['fragment'] !== '') {
+                    $rewrittenUrl .= '#'.$parts['fragment'];
+                }
+
+                return $matches['attr']
+                    .'='
+                    .$matches['quote']
+                    .htmlspecialchars($rewrittenUrl, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
+                    .$matches['quote'];
+            },
+            $content
+        );
+
+        return $normalized ?? $content;
+    }
+
+    private function resolveDirectFileUrl(string $url): string|false
+    {
+        $decodedUrl = html_entity_decode(trim($url), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        if ($decodedUrl === '' || ! str_contains($decodedUrl, '/files/get?')) {
+            return $this->normalizeAbsoluteUrl($decodedUrl);
+        }
+
+        $parts = parse_url($decodedUrl);
+
+        if ($parts === false) {
+            return false;
+        }
+
+        $path = $parts['path'] ?? '';
+        if (! in_array($path, ['/files/get', 'files/get'], true)) {
+            return $this->normalizeAbsoluteUrl($decodedUrl);
+        }
+
+        parse_str($parts['query'] ?? '', $queryParams);
+        $encName = trim((string) ($queryParams['encName'] ?? ''));
+        $extension = trim((string) ($queryParams['ext'] ?? ''));
+
+        if ($encName === '' || $extension === '') {
+            return false;
+        }
+
+        $file = $this->fileRepository->findFileByEncodedName($encName, $extension);
+
+        if ($file === false) {
+            return false;
+        }
+
+        $fileUrl = $this->fileManager->getFileUrl($encName.'.'.$extension);
+
+        if (! is_string($fileUrl) || $fileUrl === '') {
+            return false;
+        }
+
+        return $this->normalizeAbsoluteUrl($fileUrl);
+    }
+
+    private function normalizeAbsoluteUrl(string $url): string|false
+    {
+        if ($url === '') {
+            return false;
+        }
+
+        if (preg_match('#^https?://#i', $url)) {
+            return $url;
+        }
+
+        if (str_starts_with($url, '/')) {
+            return rtrim((string) BASE_URL, '/').$url;
+        }
+
+        return rtrim((string) BASE_URL, '/').'/'.$url;
     }
 
     private function getSettingKey(int $ticketId): string

--- a/tests/Unit/app/Domain/Supportcenter/Services/GithubElevationTest.php
+++ b/tests/Unit/app/Domain/Supportcenter/Services/GithubElevationTest.php
@@ -5,18 +5,32 @@ namespace Unit\app\Domain\Supportcenter\Services;
 require_once __DIR__.'/../../../../../../app/Domain/Supportcenter/Services/GithubElevation.php';
 
 use Illuminate\Support\Facades\Http;
+use Leantime\Core\Files\FileManager;
+use Leantime\Domain\Files\Repositories\Files as FileRepository;
 use Leantime\Domain\Setting\Repositories\Setting as SettingRepository;
 use Leantime\Domain\Supportcenter\Services\GithubElevation;
 use Unit\TestCase;
 
 class GithubElevationTest extends TestCase
 {
+    private function makeService(
+        ?SettingRepository $settings = null,
+        ?FileRepository $fileRepository = null,
+        ?FileManager $fileManager = null,
+    ): GithubElevation {
+        return new GithubElevation(
+            $settings ?? $this->createMock(SettingRepository::class),
+            $fileRepository ?? $this->createMock(FileRepository::class),
+            $fileManager ?? $this->createMock(FileManager::class),
+        );
+    }
+
     public function test_it_returns_false_when_no_github_issue_exists(): void
     {
         $settings = $this->createMock(SettingRepository::class);
         $settings->method('getSetting')->willReturn(false);
 
-        $service = new GithubElevation($settings);
+        $service = $this->makeService($settings);
 
         $this->assertFalse($service->getTicketGithubStatus(123));
     }
@@ -28,7 +42,7 @@ class GithubElevationTest extends TestCase
             'state' => 'open',
         ]));
 
-        $service = new GithubElevation($settings);
+        $service = $this->makeService($settings);
 
         $this->assertSame([
             'status' => 'Backlog',
@@ -44,7 +58,7 @@ class GithubElevationTest extends TestCase
             'state' => 'closed',
         ]));
 
-        $service = new GithubElevation($settings);
+        $service = $this->makeService($settings);
 
         $this->assertSame([
             'status' => 'Done',
@@ -73,7 +87,7 @@ class GithubElevationTest extends TestCase
         $settings = $this->createMock(SettingRepository::class);
         $settings->method('getSetting')->willReturn(false);
 
-        $service = new GithubElevation($settings);
+        $service = $this->makeService($settings);
         $result = $service->createGithubIssue(123, (object) ['headline' => 'Sample'], [
             'githubTitle' => 'Sample title',
             'githubSummary' => 'Sample summary',
@@ -82,5 +96,30 @@ class GithubElevationTest extends TestCase
         $this->assertFalse($result['ok']);
         $this->assertStringContainsString('GitHub repository BlueFissionTech/morpro is not visible to the configured token.', $result['message']);
         $this->assertStringContainsString('REQ123', $result['message']);
+    }
+
+    public function test_it_builds_default_title_and_markdown_summary_with_direct_file_urls(): void
+    {
+        $settings = $this->createMock(SettingRepository::class);
+        $fileRepository = $this->createMock(FileRepository::class);
+        $fileManager = $this->createMock(FileManager::class);
+        $fileRepository->method('findFileByEncodedName')->with('abc123', 'png')->willReturn([
+            'encName' => 'abc123',
+            'extension' => 'png',
+            'realName' => 'Stops.png',
+        ]);
+        $fileManager->method('getFileUrl')->with('abc123.png')->willReturn('https://s3.example.com/files/abc123.png?signature=xyz');
+
+        $service = $this->makeService($settings, $fileRepository, $fileManager);
+        $ticket = (object) [
+            'headline' => 'Need multi-stop load support',
+            'description' => '<p>User should be able to add stops to a load.</p><p><strong>Many loads are more than 1 pick-1 drop.</strong></p><img src="https://support.example.com/files/get?module=project&amp;encName=abc123&amp;ext=png&amp;realName=Stops.png" alt="Stops screenshot">',
+        ];
+
+        $this->assertSame('Need multi-stop load support', $service->getDefaultGithubTitle($ticket));
+        $this->assertSame(
+            "User should be able to add stops to a load.\nMany loads are more than 1 pick-1 drop.\n\n![Stops screenshot](https://s3.example.com/files/abc123.png?signature=xyz)",
+            $service->getDefaultGithubSummary($ticket)
+        );
     }
 }


### PR DESCRIPTION
## Intent Summary
Resolve GitHub elevation attachment references to direct file-store URLs instead of authenticated `/files/get` endpoints, so GitHub can render embedded screenshots reliably.

## User Stories / Acceptance Criteria
- Embedded images in the GitHub technical summary use direct object URLs when the file exists in storage.
- On S3-compatible storage, the generated Markdown points to the temporary/public file URL returned by the file manager.
- If direct resolution is not available, the summary falls back to a regular Markdown link instead of a broken inline image.

## Key Files Changed
- `app/Domain/Files/Repositories/Files.php`
- `app/Domain/Supportcenter/Services/GithubElevation.php`
- `tests/Unit/app/Domain/Supportcenter/Services/GithubElevationTest.php`

## How To Test
- `php -l app/Domain/Files/Repositories/Files.php`
- `php -l app/Domain/Supportcenter/Services/GithubElevation.php`
- `php -l tests/Unit/app/Domain/Supportcenter/Services/GithubElevationTest.php`
- `vendor\\bin\\phpunit tests/Unit/app/Domain/Supportcenter/Services/GithubElevationTest.php`

## QA Checklist
- Elevate a ticket with an embedded screenshot.
- Confirm the generated GitHub body uses a direct file URL rather than `/files/get?...`.
- Confirm the screenshot renders in GitHub instead of returning `Non-Image content-type returned`.

## Approval Conditions
- GitHub elevation screenshot links render correctly from production storage.
- Existing elevation text behavior remains intact.