### PR TITLE
Fix task comment user tagging regression

### DIFF
--- a/public/assets/js/app/core/tiptap/extensions/mention.js
+++ b/public/assets/js/app/core/tiptap/extensions/mention.js
@@ -62,13 +62,78 @@ const LeantimeMention = Mention.extend({
     }
 });
 
+function getContextScopes(contextElement) {
+    var scopes = [];
+    var seen = new Set();
+    var current = contextElement;
+
+    while (current && current !== document.body) {
+        if (
+            current.matches &&
+            current.matches('form, .nyroModalCont, .modal, .modal-body, [data-ticket-id], [data-project-id]')
+        ) {
+            if (!seen.has(current)) {
+                scopes.push(current);
+                seen.add(current);
+            }
+        }
+        current = current.parentElement;
+    }
+
+    if (!seen.has(document)) {
+        scopes.push(document);
+    }
+
+    return scopes;
+}
+
+function findProjectAccessTarget(contextElement) {
+    var selectors = [
+        'input[name="projectUsersAccess"]',
+        'input[name="projectId"]',
+        'select[name="projectId"]',
+        'input[name="currentProject"]',
+        '#projectIdInput',
+        '[data-project-id]'
+    ];
+    var scopes = getContextScopes(contextElement);
+
+    for (var i = 0; i < scopes.length; i++) {
+        var scope = scopes[i];
+
+        for (var j = 0; j < selectors.length; j++) {
+            var field = scope.querySelector(selectors[j]);
+            if (!field) {
+                continue;
+            }
+
+            var value = field.getAttribute('data-project-id') || field.value || '';
+            var projectId = parseInt(value, 10);
+
+            if (projectId > 0) {
+                return String(projectId);
+            }
+        }
+    }
+
+    if (window.leantime && window.leantime.currentProject) {
+        var currentProject = parseInt(window.leantime.currentProject, 10);
+        if (currentProject > 0) {
+            return String(currentProject);
+        }
+    }
+
+    return 'current';
+}
+
 /**
  * Fetch users from the API based on query
  */
-function fetchUsers(query) {
+function fetchUsers(query, contextElement) {
     return new Promise(function(resolve, reject) {
+        var projectUsersAccess = findProjectAccessTarget(contextElement);
         var url = leantime.appUrl + '/api/users?' +
-            'projectUsersAccess=current' +
+            'projectUsersAccess=' + encodeURIComponent(projectUsersAccess) +
             (query ? '&query=' + encodeURIComponent(query) : '');
 
         fetch(url, {
@@ -238,7 +303,9 @@ function createMentionExtension() {
 
             items: function(props) {
                 var query = props.query || '';
-                return fetchUsers(query).then(function(users) {
+                var contextElement = props.editor && props.editor.view ? props.editor.view.dom : null;
+
+                return fetchUsers(query, contextElement).then(function(users) {
                     // Filter by query client-side as well for faster results
                     if (query) {
                         var lowerQuery = query.toLowerCase();
@@ -329,5 +396,6 @@ function createMentionExtension() {
 // Export for use in main module
 module.exports = {
     createMentionExtension: createMentionExtension,
-    fetchUsers: fetchUsers
+    fetchUsers: fetchUsers,
+    findProjectAccessTarget: findProjectAccessTarget
 };


### PR DESCRIPTION
## Intent summary
Fix the regression where @mentions in task comments stop resolving the correct user list when the ticket context differs from the session current project.

## User stories / acceptance criteria
- As a user commenting on a task, I can type @ in the comment editor and see matching users from that task's project.
- As a user opening a task from cross-project views, mentions still resolve against the task's actual project instead of an unrelated session project.
- As a user on project-scoped views, existing mention behavior continues to work.

## Key files changed
- public/assets/js/app/core/tiptap/extensions/mention.js

## How to test
- Open a task comment editor from a project task view and type @.
- Open a task from a cross-project or My Work style view where session current project may differ, then type @ in comments.
- Confirm the autocomplete list appears and inserts the selected user mention.

## QA checklist
- [ ] @mention suggestions appear in task comments
- [ ] Selecting a suggested user inserts the mention into the comment
- [ ] Cross-project task views still resolve the correct project users
- [ ] Project-scoped task views still resolve the correct project users

## Approval conditions
- Merge after staging QA confirms task comment tagging works again in both direct project and cross-project task entry points.

Closes #142