### PR TITLE
Promote onboarding context API wrappers to master

### DIFF
--- a/app/Domain/Api/Controllers/Docs.php
+++ b/app/Domain/Api/Controllers/Docs.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Leantime\Domain\Api\Controllers;
+
+use Leantime\Core\Controller\Controller;
+use Leantime\Domain\Auth\Models\Roles;
+use Leantime\Domain\Auth\Services\Auth as AuthService;
+use Leantime\Domain\Wiki\Models\Article;
+use Leantime\Domain\Wiki\Models\Wiki as WikiModel;
+use Leantime\Domain\Wiki\Repositories\Wiki as WikiRepository;
+use Leantime\Domain\Wiki\Services\Wiki as WikiService;
+use Symfony\Component\HttpFoundation\Response;
+
+class Docs extends Controller
+{
+    private WikiService $wikiService;
+
+    private WikiRepository $wikiRepository;
+
+    public function init(WikiService $wikiService, WikiRepository $wikiRepository): void
+    {
+        $this->wikiService = $wikiService;
+        $this->wikiRepository = $wikiRepository;
+    }
+
+    public function get(array $params): Response
+    {
+        if (isset($params['activityForId'])) {
+            return $this->tpl->displayJson([
+                'status' => 'ok',
+                'result' => $this->wikiService->getArticleActivity((int) $params['activityForId']),
+            ]);
+        }
+
+        if (isset($params['id'])) {
+            if (! isset($params['projectId'])) {
+                return $this->tpl->displayJson(['status' => 'failure', 'error' => 'projectId is required for article lookup'], 400);
+            }
+
+            $article = $this->wikiService->getArticle((int) $params['id'], (int) $params['projectId']);
+
+            if ($article === false) {
+                return $this->tpl->displayJson(['status' => 'failure', 'error' => 'Document not found'], 404);
+            }
+
+            return $this->tpl->displayJson(['status' => 'ok', 'result' => $article]);
+        }
+
+        if (isset($params['canvasId'])) {
+            $userId = isset($params['userId']) ? (int) $params['userId'] : (int) (session('userdata.id') ?? 0);
+
+            return $this->tpl->displayJson([
+                'status' => 'ok',
+                'result' => $this->wikiService->getAllWikiHeadlines((int) $params['canvasId'], $userId),
+            ]);
+        }
+
+        if (isset($params['boardId'])) {
+            $wiki = $this->wikiService->getWiki((int) $params['boardId']);
+
+            if ($wiki === false) {
+                return $this->tpl->displayJson(['status' => 'failure', 'error' => 'Doc board not found'], 404);
+            }
+
+            return $this->tpl->displayJson(['status' => 'ok', 'result' => $wiki]);
+        }
+
+        if (isset($params['projectId'])) {
+            return $this->tpl->displayJson([
+                'status' => 'ok',
+                'result' => $this->wikiService->getAllProjectWikis((int) $params['projectId']),
+            ]);
+        }
+
+        return $this->tpl->displayJson(['status' => 'failure', 'error' => 'Missing docs lookup parameter'], 400);
+    }
+
+    public function post(array $params): Response
+    {
+        if (! AuthService::userIsAtLeast(Roles::$editor)) {
+            return $this->tpl->displayJson(['error' => 'Not Authorized'], 403);
+        }
+
+        if (! isset($params['action'])) {
+            return $this->tpl->displayJson(['status' => 'failure', 'error' => 'Action not set'], 400);
+        }
+
+        if ($params['action'] === 'createBoard') {
+            if (empty($params['title']) || ! isset($params['projectId'])) {
+                return $this->tpl->displayJson(['status' => 'failure', 'error' => 'title and projectId are required'], 400);
+            }
+
+            $wiki = new WikiModel;
+            $wiki->title = $params['title'];
+            $wiki->projectId = (int) $params['projectId'];
+            $wiki->author = (int) session('userdata.id');
+
+            $boardId = $this->wikiService->createWiki($wiki);
+
+            if ($boardId === false) {
+                return $this->tpl->displayJson(['status' => 'failure'], 500);
+            }
+
+            return $this->tpl->displayJson(['status' => 'ok', 'result' => ['boardId' => (int) $boardId]], 201);
+        }
+
+        if ($params['action'] === 'createItem') {
+            if (! isset($params['canvasId']) || empty($params['title'])) {
+                return $this->tpl->displayJson(['status' => 'failure', 'error' => 'canvasId and title are required'], 400);
+            }
+
+            $article = new Article;
+            $article->title = $params['title'];
+            $article->description = $params['description'] ?? '';
+            $article->data = $params['data'] ?? '';
+            $article->canvasId = (int) $params['canvasId'];
+            $article->parent = (int) ($params['parent'] ?? 0);
+            $article->tags = $params['tags'] ?? '';
+            $article->status = $params['status'] ?? 'draft';
+            $article->author = (int) session('userdata.id');
+            $article->milestoneId = $params['milestoneId'] ?? '';
+
+            $itemId = $this->wikiService->createArticle($article);
+
+            if ($itemId === false) {
+                return $this->tpl->displayJson(['status' => 'failure'], 500);
+            }
+
+            return $this->tpl->displayJson(['status' => 'ok', 'result' => ['itemId' => (int) $itemId]], 201);
+        }
+
+        return $this->tpl->displayJson(['status' => 'failure', 'error' => 'Unsupported action'], 400);
+    }
+
+    public function patch(array $params): Response
+    {
+        if (! AuthService::userIsAtLeast(Roles::$editor)) {
+            return $this->tpl->displayJson(['error' => 'Not Authorized'], 403);
+        }
+
+        if (isset($params['boardId'])) {
+            if (empty($params['title'])) {
+                return $this->tpl->displayJson(['status' => 'failure', 'error' => 'title is required'], 400);
+            }
+
+            $wiki = new WikiModel;
+            $wiki->title = $params['title'];
+
+            if (! $this->wikiService->updateWiki($wiki, (int) $params['boardId'])) {
+                return $this->tpl->displayJson(['status' => 'failure'], 500);
+            }
+
+            return $this->tpl->displayJson(['status' => 'ok']);
+        }
+
+        if (! isset($params['id'], $params['projectId'])) {
+            return $this->tpl->displayJson(['status' => 'failure', 'error' => 'id and projectId are required'], 400);
+        }
+
+        $existing = $this->wikiService->getArticle((int) $params['id'], (int) $params['projectId']);
+        if ($existing === false) {
+            return $this->tpl->displayJson(['status' => 'failure', 'error' => 'Document not found'], 404);
+        }
+
+        $article = new Article;
+        $article->id = (int) $params['id'];
+        $article->title = $params['title'] ?? $existing->title;
+        $article->description = $params['description'] ?? $existing->description;
+        $article->data = $params['data'] ?? $existing->data;
+        $article->parent = (int) ($params['parent'] ?? $existing->parent);
+        $article->tags = $params['tags'] ?? $existing->tags;
+        $article->status = $params['status'] ?? $existing->status;
+        $article->milestoneId = $params['milestoneId'] ?? $existing->milestoneId;
+
+        if (! $this->wikiService->updateArticle($article, $existing)) {
+            return $this->tpl->displayJson(['status' => 'failure'], 500);
+        }
+
+        return $this->tpl->displayJson(['status' => 'ok']);
+    }
+
+    public function delete(array $params): Response
+    {
+        if (! AuthService::userIsAtLeast(Roles::$editor)) {
+            return $this->tpl->displayJson(['error' => 'Not Authorized'], 403);
+        }
+
+        if (isset($params['boardId'])) {
+            $this->wikiRepository->delWiki((int) $params['boardId']);
+
+            return $this->tpl->displayJson(['status' => 'ok']);
+        }
+
+        if (isset($params['id'])) {
+            $this->wikiRepository->delArticle((int) $params['id']);
+
+            return $this->tpl->displayJson(['status' => 'ok']);
+        }
+
+        return $this->tpl->displayJson(['status' => 'failure', 'error' => 'Missing delete target'], 400);
+    }
+}

--- a/app/Domain/Api/Controllers/Files.php
+++ b/app/Domain/Api/Controllers/Files.php
@@ -3,6 +3,8 @@
 namespace Leantime\Domain\Api\Controllers;
 
 use Leantime\Core\Controller\Controller;
+use Leantime\Domain\Auth\Models\Roles;
+use Leantime\Domain\Auth\Services\Auth as AuthService;
 use Leantime\Domain\Files\Services\Files as FileService;
 use Leantime\Domain\Users\Services\Users as UserService;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,7 +29,28 @@ class Files extends Controller
      */
     public function get(array $params): Response
     {
-        return $this->tpl->displayJson(['status' => 'Not implemented'], 501);
+        if (isset($params['id'])) {
+            $file = $this->fileService->getFile((int) $params['id']);
+
+            if ($file === false) {
+                return $this->tpl->displayJson(['status' => 'failure', 'error' => 'File not found'], 404);
+            }
+
+            return $this->tpl->displayJson(['status' => 'ok', 'result' => $file]);
+        }
+
+        if (isset($params['module'])) {
+            return $this->tpl->displayJson([
+                'status' => 'ok',
+                'result' => $this->fileService->getFilesByModule(
+                    (string) $params['module'],
+                    isset($params['moduleId']) ? (int) $params['moduleId'] : null,
+                    isset($params['userId']) ? (int) $params['userId'] : null
+                ),
+            ]);
+        }
+
+        return $this->tpl->displayJson(['status' => 'failure', 'error' => 'Missing file lookup parameter'], 400);
     }
 
     /**
@@ -40,10 +63,16 @@ class Files extends Controller
      */
     public function post(array $params): Response
     {
+        if (! AuthService::userIsAtLeast(Roles::$editor)) {
+            return $this->tpl->displayJson(['error' => 'Not Authorized'], 403);
+        }
+
         // FileUpload
-        if (isset($_FILES['file']) && isset($_GET['module']) && isset($_GET['moduleId'])) {
-            $module = htmlentities($_GET['module']);
-            $id = (int) $_GET['moduleId'];
+        $module = $params['module'] ?? $_GET['module'] ?? null;
+        $id = isset($params['moduleId']) ? (int) $params['moduleId'] : (isset($_GET['moduleId']) ? (int) $_GET['moduleId'] : null);
+
+        if (isset($_FILES['file']) && $module !== null && $id !== null) {
+            $module = htmlentities((string) $module);
 
             $result = $this->fileService->upload($_FILES, $module, $id);
             if (is_string($result)) {
@@ -81,14 +110,23 @@ class Files extends Controller
      */
     public function patch(array $params): Response
     {
-        if (
-            ! isset($params['patchModalSettings'])
-            || ! $this->userService->updateUserSettings('modals', $params['settings'], 1)
-        ) {
-            return $this->tpl->displayJson(['status' => 'failure'], 500);
+        if (isset($params['id'])) {
+            if (! AuthService::userIsAtLeast(Roles::$editor)) {
+                return $this->tpl->displayJson(['error' => 'Not Authorized'], 403);
+            }
+
+            if (! $this->fileService->updateFile((int) $params['id'], $params)) {
+                return $this->tpl->displayJson(['status' => 'failure'], 500);
+            }
+
+            return $this->tpl->displayJson(['status' => 'ok']);
         }
 
-        return $this->tpl->displayJson(['status' => 'ok']);
+        if (isset($params['patchModalSettings']) && $this->userService->updateUserSettings('modals', $params['settings'], 1)) {
+            return $this->tpl->displayJson(['status' => 'ok']);
+        }
+
+        return $this->tpl->displayJson(['status' => 'failure'], 500);
     }
 
     /**
@@ -96,6 +134,14 @@ class Files extends Controller
      */
     public function delete(array $params): Response
     {
-        return $this->tpl->displayJson(['status' => 'Not implemented'], 501);
+        if (! AuthService::userIsAtLeast(Roles::$editor)) {
+            return $this->tpl->displayJson(['error' => 'Not Authorized'], 403);
+        }
+
+        if (! isset($params['id']) || ! $this->fileService->deleteFile((int) $params['id'])) {
+            return $this->tpl->displayJson(['status' => 'failure'], 500);
+        }
+
+        return $this->tpl->displayJson(['status' => 'ok']);
     }
 }

--- a/app/Domain/Api/Controllers/Files.php
+++ b/app/Domain/Api/Controllers/Files.php
@@ -115,7 +115,23 @@ class Files extends Controller
                 return $this->tpl->displayJson(['error' => 'Not Authorized'], 403);
             }
 
-            if (! $this->fileService->updateFile((int) $params['id'], $params)) {
+            $fileId = (int) $params['id'];
+            $existingFile = $this->fileService->getFile($fileId);
+
+            if ($existingFile === false) {
+                return $this->tpl->displayJson(['status' => 'failure', 'error' => 'File not found'], 404);
+            }
+
+            $updates = $this->fileService->getApiMetadataUpdates($params);
+
+            if ($updates === []) {
+                return $this->tpl->displayJson([
+                    'status' => 'failure',
+                    'error' => 'No supported file metadata fields were supplied',
+                ], 400);
+            }
+
+            if (! $this->fileService->updateFile($fileId, $updates)) {
                 return $this->tpl->displayJson(['status' => 'failure'], 500);
             }
 
@@ -138,7 +154,16 @@ class Files extends Controller
             return $this->tpl->displayJson(['error' => 'Not Authorized'], 403);
         }
 
-        if (! isset($params['id']) || ! $this->fileService->deleteFile((int) $params['id'])) {
+        if (! isset($params['id'])) {
+            return $this->tpl->displayJson(['status' => 'failure', 'error' => 'Missing file id'], 400);
+        }
+
+        $fileId = (int) $params['id'];
+        if ($this->fileService->getFile($fileId) === false) {
+            return $this->tpl->displayJson(['status' => 'failure', 'error' => 'File not found'], 404);
+        }
+
+        if (! $this->fileService->deleteFile($fileId)) {
             return $this->tpl->displayJson(['status' => 'failure'], 500);
         }
 

--- a/app/Domain/Api/Controllers/Ideas.php
+++ b/app/Domain/Api/Controllers/Ideas.php
@@ -3,6 +3,8 @@
 namespace Leantime\Domain\Api\Controllers;
 
 use Leantime\Core\Controller\Controller;
+use Leantime\Domain\Auth\Models\Roles;
+use Leantime\Domain\Auth\Services\Auth as AuthService;
 use Leantime\Domain\Ideas\Repositories\Ideas as IdeaRepository;
 use Leantime\Domain\Projects\Repositories\Projects as ProjectRepository;
 use Symfony\Component\HttpFoundation\Response;
@@ -33,7 +35,41 @@ class Ideas extends Controller
      */
     public function get(array $params): Response
     {
-        return $this->tpl->displayJson(['status' => 'Not implemented'], 501);
+        if (isset($params['id'])) {
+            $item = $this->ideaAPIRepo->getSingleCanvasItem((int) $params['id']);
+
+            if ($item === false) {
+                return $this->tpl->displayJson(['status' => 'failure', 'error' => 'Idea item not found'], 404);
+            }
+
+            return $this->tpl->displayJson(['status' => 'ok', 'result' => $item]);
+        }
+
+        if (isset($params['canvasId'])) {
+            return $this->tpl->displayJson([
+                'status' => 'ok',
+                'result' => $this->ideaAPIRepo->getCanvasItemsById((int) $params['canvasId']),
+            ]);
+        }
+
+        if (isset($params['boardId'])) {
+            $board = $this->ideaAPIRepo->getSingleCanvas((int) $params['boardId']);
+
+            if ($board === false || count($board) === 0) {
+                return $this->tpl->displayJson(['status' => 'failure', 'error' => 'Idea board not found'], 404);
+            }
+
+            return $this->tpl->displayJson(['status' => 'ok', 'result' => $board]);
+        }
+
+        if (isset($params['projectId'])) {
+            return $this->tpl->displayJson([
+                'status' => 'ok',
+                'result' => $this->ideaAPIRepo->getAllCanvas((int) $params['projectId']),
+            ]);
+        }
+
+        return $this->tpl->displayJson(['status' => 'failure', 'error' => 'Missing idea lookup parameter'], 400);
     }
 
     /**
@@ -41,6 +77,52 @@ class Ideas extends Controller
      */
     public function post(array $params): Response
     {
+        if (! AuthService::userIsAtLeast(Roles::$editor)) {
+            return $this->tpl->displayJson(['error' => 'Not Authorized'], 403);
+        }
+
+        if (isset($params['action']) && $params['action'] === 'createBoard') {
+            if (empty($params['title']) || ! isset($params['projectId'])) {
+                return $this->tpl->displayJson(['status' => 'failure', 'error' => 'title and projectId are required'], 400);
+            }
+
+            $boardId = $this->ideaAPIRepo->addCanvas([
+                'title' => $params['title'],
+                'author' => session('userdata.id'),
+                'projectId' => (int) $params['projectId'],
+            ]);
+
+            if ($boardId === false) {
+                return $this->tpl->displayJson(['status' => 'failure'], 500);
+            }
+
+            return $this->tpl->displayJson(['status' => 'ok', 'result' => ['boardId' => (int) $boardId]], 201);
+        }
+
+        if (isset($params['action']) && $params['action'] === 'createItem') {
+            if (! isset($params['canvasId'])) {
+                return $this->tpl->displayJson(['status' => 'failure', 'error' => 'canvasId is required'], 400);
+            }
+
+            $itemId = $this->ideaAPIRepo->addCanvasItem([
+                'description' => $params['description'] ?? '',
+                'assumptions' => $params['assumptions'] ?? '',
+                'data' => $params['data'] ?? '',
+                'conclusion' => $params['conclusion'] ?? '',
+                'box' => $params['box'] ?? 'idea',
+                'author' => session('userdata.id'),
+                'canvasId' => (int) $params['canvasId'],
+                'status' => $params['status'] ?? '',
+                'milestoneId' => $params['milestoneId'] ?? '',
+            ]);
+
+            if ($itemId === false) {
+                return $this->tpl->displayJson(['status' => 'failure'], 500);
+            }
+
+            return $this->tpl->displayJson(['status' => 'ok', 'result' => ['itemId' => (int) $itemId]], 201);
+        }
+
         if (isset($params['action']) && $params['action'] == 'ideaSort' && isset($params['payload']) === true) {
             if (! $this->ideaAPIRepo->updateIdeaSorting($params['payload'])) {
                 return $this->tpl->displayJson(['status' => 'failure'], 500);
@@ -57,7 +139,7 @@ class Ideas extends Controller
             return $this->tpl->displayJson(['status' => 'ok']);
         }
 
-        return $this->tpl->displayJson(['status' => 'failure'], 500);
+        return $this->tpl->displayJson(['status' => 'failure', 'error' => 'Unsupported action'], 400);
     }
 
     /**
@@ -65,7 +147,26 @@ class Ideas extends Controller
      */
     public function patch(array $params): Response
     {
-        if (! isset($params['id']) || ! $this->ideaAPIRepo->patchCanvasItem($params['id'], $params)) {
+        if (! AuthService::userIsAtLeast(Roles::$editor)) {
+            return $this->tpl->displayJson(['error' => 'Not Authorized'], 403);
+        }
+
+        if (isset($params['boardId'])) {
+            if (empty($params['title'])) {
+                return $this->tpl->displayJson(['status' => 'failure', 'error' => 'title is required'], 400);
+            }
+
+            if (! $this->ideaAPIRepo->updateCanvas([
+                'id' => (int) $params['boardId'],
+                'title' => $params['title'],
+            ])) {
+                return $this->tpl->displayJson(['status' => 'failure'], 500);
+            }
+
+            return $this->tpl->displayJson(['status' => 'ok']);
+        }
+
+        if (! isset($params['id']) || ! $this->ideaAPIRepo->patchCanvasItem((int) $params['id'], $params)) {
             return $this->tpl->displayJson(['status' => 'failure'], 500);
         }
 
@@ -77,6 +178,22 @@ class Ideas extends Controller
      */
     public function delete(array $params): Response
     {
-        return $this->tpl->displayJson(['status' => 'Not implemented'], 501);
+        if (! AuthService::userIsAtLeast(Roles::$editor)) {
+            return $this->tpl->displayJson(['error' => 'Not Authorized'], 403);
+        }
+
+        if (isset($params['boardId'])) {
+            $this->ideaAPIRepo->deleteCanvas((int) $params['boardId']);
+
+            return $this->tpl->displayJson(['status' => 'ok']);
+        }
+
+        if (isset($params['id'])) {
+            $this->ideaAPIRepo->delCanvasItem((int) $params['id']);
+
+            return $this->tpl->displayJson(['status' => 'ok']);
+        }
+
+        return $this->tpl->displayJson(['status' => 'failure', 'error' => 'Missing delete target'], 400);
     }
 }

--- a/app/Domain/Api/Controllers/Reports.php
+++ b/app/Domain/Api/Controllers/Reports.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Leantime\Domain\Api\Controllers;
+
+use Leantime\Core\Controller\Controller;
+use Leantime\Domain\Comments\Services\Comments as CommentService;
+use Leantime\Domain\Reports\Repositories\Reports as ReportRepository;
+use Leantime\Domain\Reports\Services\Reports as ReportService;
+use Symfony\Component\HttpFoundation\Response;
+
+class Reports extends Controller
+{
+    private ReportService $reportService;
+
+    private ReportRepository $reportRepository;
+
+    private CommentService $commentService;
+
+    public function init(
+        ReportService $reportService,
+        ReportRepository $reportRepository,
+        CommentService $commentService
+    ): void {
+        $this->reportService = $reportService;
+        $this->reportRepository = $reportRepository;
+        $this->commentService = $commentService;
+    }
+
+    public function get(array $params): Response
+    {
+        if (! isset($params['projectId'])) {
+            return $this->tpl->displayJson(['status' => 'failure', 'error' => 'projectId is required'], 400);
+        }
+
+        $projectId = (int) $params['projectId'];
+        $report = $params['report'] ?? 'full';
+
+        return match ($report) {
+            'full' => $this->tpl->displayJson(['status' => 'ok', 'result' => $this->reportService->getFullReport($projectId)]),
+            'realtime' => $this->tpl->displayJson(['status' => 'ok', 'result' => $this->reportService->getRealtimeReport($projectId, (string) ($params['sprintId'] ?? ''))]),
+            'backlog' => $this->tpl->displayJson(['status' => 'ok', 'result' => $this->reportRepository->getBacklogReport($projectId)]),
+            'sprint' => isset($params['sprintId'])
+                ? $this->tpl->displayJson(['status' => 'ok', 'result' => $this->reportRepository->getSprintReport((int) $params['sprintId'])])
+                : $this->tpl->displayJson(['status' => 'failure', 'error' => 'sprintId is required'], 400),
+            'projectStatusSummary' => $this->tpl->displayJson(['status' => 'ok', 'result' => $this->reportService->getProjectStatusReport()]),
+            'statusHistory' => $this->tpl->displayJson([
+                'status' => 'ok',
+                'result' => [
+                    'qualitative' => $this->commentService->getComments('project', $projectId, 1),
+                    'quantitative' => $this->reportService->getFullReport($projectId),
+                    'realtime' => $this->reportService->getRealtimeReport($projectId, (string) ($params['sprintId'] ?? '')),
+                ],
+            ]),
+            default => $this->tpl->displayJson(['status' => 'failure', 'error' => 'Unsupported report type'], 400),
+        };
+    }
+
+    public function post(array $params): Response
+    {
+        return $this->tpl->displayJson(['status' => 'Not implemented'], 501);
+    }
+
+    public function patch(array $params): Response
+    {
+        return $this->tpl->displayJson(['status' => 'Not implemented'], 501);
+    }
+
+    public function delete(array $params): Response
+    {
+        return $this->tpl->displayJson(['status' => 'Not implemented'], 501);
+    }
+}

--- a/app/Domain/Files/Repositories/Files.php
+++ b/app/Domain/Files/Repositories/Files.php
@@ -184,6 +184,27 @@ class Files
             ->delete() > 0;
     }
 
+    public function updateFile(int $id, array $values): bool
+    {
+        $allowed = ['realName', 'module', 'moduleId'];
+        $updates = [];
+
+        foreach ($allowed as $field) {
+            if (array_key_exists($field, $values)) {
+                $updates[$field] = $values[$field];
+            }
+        }
+
+        if ($updates === []) {
+            return false;
+        }
+
+        return $this->db->table('zp_file')
+            ->where('id', $id)
+            ->limit(1)
+            ->update($updates) >= 0;
+    }
+
     /**
      * @return array|false
      *

--- a/app/Domain/Files/Services/Files.php
+++ b/app/Domain/Files/Services/Files.php
@@ -149,6 +149,25 @@ class Files
         return $this->fileRepository->updateFile($fileId, $values);
     }
 
+    public function getApiMetadataUpdates(array $values): array
+    {
+        $updates = [];
+
+        if (array_key_exists('realName', $values)) {
+            $updates['realName'] = (string) $values['realName'];
+        }
+
+        if (array_key_exists('module', $values)) {
+            $updates['module'] = (string) $values['module'];
+        }
+
+        if (array_key_exists('moduleId', $values)) {
+            $updates['moduleId'] = (int) $values['moduleId'];
+        }
+
+        return $updates;
+    }
+
     public function getFilePathById($fileId): false|string
     {
         $dbReference = $this->fileRepository->getFile($fileId);

--- a/app/Domain/Files/Services/Files.php
+++ b/app/Domain/Files/Services/Files.php
@@ -36,6 +36,11 @@ class Files
         return $this->fileRepository->getFilesByModule($module, $entityId, $userId);
     }
 
+    public function getFile(int $fileId): false|array
+    {
+        return $this->fileRepository->getFile($fileId);
+    }
+
     /**
      * @throws BindingResolutionException
      *
@@ -137,6 +142,11 @@ class Files
     public function deleteFile($fileId): bool
     {
         return $this->fileRepository->deleteFile($fileId);
+    }
+
+    public function updateFile(int $fileId, array $values): bool
+    {
+        return $this->fileRepository->updateFile($fileId, $values);
     }
 
     public function getFilePathById($fileId): false|string

--- a/tests/Unit/app/Domain/Api/Controllers/DocsApiSourceTest.php
+++ b/tests/Unit/app/Domain/Api/Controllers/DocsApiSourceTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Unit\app\Domain\Api\Controllers;
+
+use Unit\TestCase;
+
+class DocsApiSourceTest extends TestCase
+{
+    public function test_docs_api_controller_supports_wiki_board_and_article_crud(): void
+    {
+        $controller = file_get_contents(__DIR__.'/../../../../../../app/Domain/Api/Controllers/Docs.php');
+
+        $this->assertIsString($controller);
+        $this->assertStringContainsString("if (isset(\$params['projectId']))", $controller);
+        $this->assertStringContainsString("if (isset(\$params['canvasId']))", $controller);
+        $this->assertStringContainsString("if (\$params['action'] === 'createBoard')", $controller);
+        $this->assertStringContainsString("if (\$params['action'] === 'createItem')", $controller);
+        $this->assertStringContainsString("\$this->wikiRepository->delWiki((int) \$params['boardId'])", $controller);
+        $this->assertStringContainsString("\$this->wikiRepository->delArticle((int) \$params['id'])", $controller);
+    }
+}

--- a/tests/Unit/app/Domain/Api/Controllers/FilesApiSourceTest.php
+++ b/tests/Unit/app/Domain/Api/Controllers/FilesApiSourceTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Unit\app\Domain\Api\Controllers;
+
+use Unit\TestCase;
+
+class FilesApiSourceTest extends TestCase
+{
+    public function test_files_api_controller_supports_lookup_upload_update_and_delete(): void
+    {
+        $controller = file_get_contents(__DIR__.'/../../../../../../app/Domain/Api/Controllers/Files.php');
+
+        $this->assertIsString($controller);
+        $this->assertStringContainsString("if (isset(\$params['id']))", $controller);
+        $this->assertStringContainsString("if (isset(\$params['module']))", $controller);
+        $this->assertStringContainsString("if (isset(\$_FILES['file']) && \$module !== null && \$id !== null)", $controller);
+        $this->assertStringContainsString("\$this->fileService->updateFile((int) \$params['id'], \$params)", $controller);
+        $this->assertStringContainsString("\$this->fileService->deleteFile((int) \$params['id'])", $controller);
+    }
+}

--- a/tests/Unit/app/Domain/Api/Controllers/FilesApiSourceTest.php
+++ b/tests/Unit/app/Domain/Api/Controllers/FilesApiSourceTest.php
@@ -14,7 +14,23 @@ class FilesApiSourceTest extends TestCase
         $this->assertStringContainsString("if (isset(\$params['id']))", $controller);
         $this->assertStringContainsString("if (isset(\$params['module']))", $controller);
         $this->assertStringContainsString("if (isset(\$_FILES['file']) && \$module !== null && \$id !== null)", $controller);
-        $this->assertStringContainsString("\$this->fileService->updateFile((int) \$params['id'], \$params)", $controller);
-        $this->assertStringContainsString("\$this->fileService->deleteFile((int) \$params['id'])", $controller);
+        $this->assertStringContainsString("\$this->fileService->getFile(\$fileId)", $controller);
+        $this->assertStringContainsString("\$updates = \$this->fileService->getApiMetadataUpdates(\$params);", $controller);
+        $this->assertStringContainsString("No supported file metadata fields were supplied", $controller);
+        $this->assertStringContainsString("\$this->fileService->updateFile(\$fileId, \$updates)", $controller);
+        $this->assertStringContainsString("Missing file id", $controller);
+        $this->assertStringContainsString("\$this->fileService->deleteFile(\$fileId)", $controller);
+    }
+
+    public function test_files_service_exposes_api_metadata_update_filter(): void
+    {
+        $service = file_get_contents(__DIR__.'/../../../../../../app/Domain/Files/Services/Files.php');
+
+        $this->assertIsString($service);
+        $this->assertStringContainsString('public function getFile(int $fileId): false|array', $service);
+        $this->assertStringContainsString('public function getApiMetadataUpdates(array $values): array', $service);
+        $this->assertStringContainsString("if (array_key_exists('realName', \$values))", $service);
+        $this->assertStringContainsString("if (array_key_exists('module', \$values))", $service);
+        $this->assertStringContainsString("if (array_key_exists('moduleId', \$values))", $service);
     }
 }

--- a/tests/Unit/app/Domain/Api/Controllers/IdeasApiSourceTest.php
+++ b/tests/Unit/app/Domain/Api/Controllers/IdeasApiSourceTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Unit\app\Domain\Api\Controllers;
+
+use Unit\TestCase;
+
+class IdeasApiSourceTest extends TestCase
+{
+    public function test_ideas_api_controller_supports_full_board_and_item_crud(): void
+    {
+        $controller = file_get_contents(__DIR__.'/../../../../../../app/Domain/Api/Controllers/Ideas.php');
+
+        $this->assertIsString($controller);
+        $this->assertStringContainsString("if (isset(\$params['projectId']))", $controller);
+        $this->assertStringContainsString("if (isset(\$params['boardId']))", $controller);
+        $this->assertStringContainsString("\$params['action'] === 'createBoard'", $controller);
+        $this->assertStringContainsString("\$params['action'] === 'createItem'", $controller);
+        $this->assertStringContainsString("\$this->ideaAPIRepo->deleteCanvas((int) \$params['boardId'])", $controller);
+        $this->assertStringContainsString("\$this->ideaAPIRepo->delCanvasItem((int) \$params['id'])", $controller);
+    }
+}

--- a/tests/Unit/app/Domain/Api/Controllers/ReportsApiSourceTest.php
+++ b/tests/Unit/app/Domain/Api/Controllers/ReportsApiSourceTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Unit\app\Domain\Api\Controllers;
+
+use Unit\TestCase;
+
+class ReportsApiSourceTest extends TestCase
+{
+    public function test_reports_api_controller_supports_history_and_report_variants(): void
+    {
+        $controller = file_get_contents(__DIR__.'/../../../../../../app/Domain/Api/Controllers/Reports.php');
+
+        $this->assertIsString($controller);
+        $this->assertStringContainsString("'full' =>", $controller);
+        $this->assertStringContainsString("'realtime' =>", $controller);
+        $this->assertStringContainsString("'backlog' =>", $controller);
+        $this->assertStringContainsString("'sprint' =>", $controller);
+        $this->assertStringContainsString("'projectStatusSummary' =>", $controller);
+        $this->assertStringContainsString("'statusHistory' =>", $controller);
+        $this->assertStringContainsString("'qualitative' => \$this->commentService->getComments('project', \$projectId, 1)", $controller);
+    }
+}


### PR DESCRIPTION
## Intent summary
Promote the staged onboarding/context API wrapper tranche to master.

## User stories / acceptance criteria
- `Ideas` API supports board and item CRUD/read paths.
- `Docs` API wraps wiki boards, articles, and activity paths.
- `Files` API supports read, list, upload, metadata update, and delete paths.
- `Reports` API exposes quantitative history and combined project status history reads.
- No parallel onboarding artifact model is introduced.

## Key files changed
- `app/Domain/Api/Controllers/Ideas.php`
- `app/Domain/Api/Controllers/Files.php`
- `app/Domain/Api/Controllers/Docs.php`
- `app/Domain/Api/Controllers/Reports.php`
- `app/Domain/Files/Repositories/Files.php`
- `app/Domain/Files/Services/Files.php`
- `tests/Unit/app/Domain/Api/Controllers/IdeasApiSourceTest.php`
- `tests/Unit/app/Domain/Api/Controllers/DocsApiSourceTest.php`
- `tests/Unit/app/Domain/Api/Controllers/FilesApiSourceTest.php`
- `tests/Unit/app/Domain/Api/Controllers/ReportsApiSourceTest.php`

## How to test
- `php ..\\..\\vendor\\bin\\codecept run Unit tests/Unit/app/Domain/Api/Controllers/IdeasApiSourceTest.php`
- `php ..\\..\\vendor\\bin\\codecept run Unit tests/Unit/app/Domain/Api/Controllers/DocsApiSourceTest.php`
- `php ..\\..\\vendor\\bin\\codecept run Unit tests/Unit/app/Domain/Api/Controllers/FilesApiSourceTest.php`
- `php ..\\..\\vendor\\bin\\codecept run Unit tests/Unit/app/Domain/Api/Controllers/ReportsApiSourceTest.php`

## QA checklist
- [ ] `GET/POST/PATCH/DELETE /api/ideas` works for board and item paths.
- [ ] `GET/POST/PATCH/DELETE /api/docs` works for wiki board and article paths.
- [ ] `GET/POST/PATCH/DELETE /api/files` works for metadata, list, upload, and delete paths.
- [ ] `GET /api/reports` supports the staged report modes.

## Approval conditions
- Promote after staging validation confirms the wrapper contract is still the desired production API surface.

## Notes
- This tranche overlaps the same files API surface promoted separately in `#146`. Review and merge `#146` first, then land this wrapper tranche so the broader API work inherits the narrowed file error-handling behavior cleanly.