### PR TITLE
Promote table-view horizontal scroll fix to master

### DIFF
--- a/app/Domain/Tickets/Templates/showAll.tpl.php
+++ b/app/Domain/Tickets/Templates/showAll.tpl.php
@@ -90,6 +90,7 @@ $tpl->dispatchTplEvent('filters.beforeLefthandSectionClose');
                 <?php $allTickets = $group['items']; ?>
 
                 <?php $tpl->dispatchTplEvent('allTicketsTable.before', ['tickets' => $allTicketGroups]); ?>
+                <div class="ticket-table-scroll">
                 <table class="table table-bordered display ticketTable " style="width:100%">
                 <colgroup>
                     <col class="con1">
@@ -378,6 +379,7 @@ $tpl->dispatchTplEvent('filters.beforeLefthandSectionClose');
                     </tfoot>
 
                 </table>
+                </div>
                 <?php $tpl->dispatchTplEvent('allTicketsTable.afterClose', ['tickets' => $allTickets]); ?>
 
             <?php if ($group['label'] != 'all') { ?>

--- a/public/assets/css/components/style.default.css
+++ b/public/assets/css/components/style.default.css
@@ -3086,3 +3086,14 @@ body a.btn-link.btn-fancy:hover {
 .newWidget {
     border:1px solid var(--accent2);
 }
+
+.ticket-table-scroll {
+    width: 100%;
+    overflow-x: auto;
+    overflow-y: visible;
+    -webkit-overflow-scrolling: touch;
+}
+
+.ticket-table-scroll .ticketTable {
+    min-width: 1280px;
+}

--- a/tests/Unit/app/Domain/Tickets/Templates/ShowAllTableTemplateTest.php
+++ b/tests/Unit/app/Domain/Tickets/Templates/ShowAllTableTemplateTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Unit\app\Domain\Tickets\Templates;
+
+use Unit\TestCase;
+
+class ShowAllTableTemplateTest extends TestCase
+{
+    public function test_table_views_wrap_ticket_table_in_scroll_container(): void
+    {
+        $showAll = file_get_contents(__DIR__.'/../../../../../../app/Domain/Tickets/Templates/showAll.tpl.php');
+
+        $this->assertIsString($showAll);
+        $this->assertStringContainsString('<div class="ticket-table-scroll">', $showAll);
+    }
+
+    public function test_table_scroll_styles_enable_horizontal_overflow_for_ticket_tables(): void
+    {
+        $styles = file_get_contents(__DIR__.'/../../../../../../public/assets/css/components/style.default.css');
+
+        $this->assertIsString($styles);
+        $this->assertStringContainsString('.ticket-table-scroll {', $styles);
+        $this->assertStringContainsString('overflow-x: auto;', $styles);
+        $this->assertStringContainsString('.ticket-table-scroll .ticketTable {', $styles);
+        $this->assertStringContainsString('min-width: 1280px;', $styles);
+    }
+}


### PR DESCRIPTION
## Intent summary
Promote the staged table-view horizontal-scroll fix to master.

## User stories / acceptance criteria
- As a user, the ticket table remains usable on standard monitor widths without columns disappearing off-screen.
- As a user, I can horizontally scroll the table when needed instead of losing columns beyond the viewport.
- The production table view gains the same scroll container behavior validated on staging.

## Key files changed
- `app/Domain/Tickets/Templates/showAll.tpl.php`
- `public/assets/css/components/style.default.css`
- `tests/Unit/app/Domain/Tickets/Templates/ShowAllTableTemplateTest.php`

## How to test
- `php -l tests/Unit/app/Domain/Tickets/Templates/ShowAllTableTemplateTest.php`
- Open the main ticket table view on a standard desktop width.
- Confirm the table is wrapped in a horizontal scroll container and the columns remain reachable.

## QA checklist
- [ ] Ticket table fits within the viewport instead of bleeding past the page edge.
- [ ] Horizontal scroll appears when needed.
- [ ] Existing table interactions remain usable.

## Approval conditions
- Promote after the staged table usability improvement is confirmed on production.

## Notes
- Current `master` no longer carries the old `showAllV2` template path from staging, so this promotion applies the validated scroll behavior to the active production table template only.