### PR TITLE
Promote admin branding controls to production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,9 @@ config/.env
 tests/Httprequests/http-client.private.env.json
 .claude/docs/personal-companion-requirements.md
 .claude/docs/git-workflow.md
+/.env
+/.env.*
+!/.env.example
 
 # Blue Fission Codex harness
 /docker/

--- a/.gitignore
+++ b/.gitignore
@@ -136,10 +136,6 @@ config/.env
 tests/Httprequests/http-client.private.env.json
 .claude/docs/personal-companion-requirements.md
 .claude/docs/git-workflow.md
-/.env
-/.env.*
-!/.env.example
-
 # Blue Fission Codex harness
 /docker/
 /scripts/

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ config/.env
 tests/Httprequests/http-client.private.env.json
 .claude/docs/personal-companion-requirements.md
 .claude/docs/git-workflow.md
+
 # Blue Fission Codex harness
 /docker/
 /scripts/

--- a/app/Core/UI/Theme.php
+++ b/app/Core/UI/Theme.php
@@ -479,7 +479,14 @@ class Theme
             return $_COOKIE['colorScheme'];
         }
 
-        if (! empty($this->config->primarycolor) && ! empty($this->config->secondarycolor)) {
+        $companyPrimaryColor = $this->settingsRepo->getSetting('companysettings.primarycolor');
+        $companySecondaryColor = $this->settingsRepo->getSetting('companysettings.secondarycolor');
+
+        if (
+            (! empty($this->config->primarycolor) && ! empty($this->config->secondarycolor))
+            || $companyPrimaryColor !== false
+            || $companySecondaryColor !== false
+        ) {
             // Return default
             $this->setColorScheme('companyColors');
 
@@ -985,7 +992,7 @@ class Theme
                 session(['usersettings.colors.secondaryColor' => $this->config->secondaryColor]);
             }
 
-            $secondaryColor = $this->settingsRepo->getSetting('companysettings.secondaryColor');
+            $secondaryColor = $this->settingsRepo->getSetting('companysettings.secondarycolor');
             if ($secondaryColor !== false) {
                 session(['usersettings.colors.secondaryColor' => $secondaryColor]);
             }

--- a/app/Domain/Setting/Controllers/EditCompanySettings.php
+++ b/app/Domain/Setting/Controllers/EditCompanySettings.php
@@ -136,8 +136,11 @@ class EditCompanySettings extends Controller
     {
         // Look & feel updates
         if (isset($params['primarycolor']) && $params['primarycolor'] != '') {
-            $this->settingsRepo->saveSetting('companysettings.primarycolor', htmlentities(addslashes($params['primarycolor'])));
-            $this->settingsRepo->saveSetting('companysettings.secondarycolor', htmlentities(addslashes($params['secondarycolor'])));
+            $primaryColor = $this->sanitizeHexColor($params['primarycolor']);
+            $secondaryColor = $this->sanitizeHexColor($params['secondarycolor'] ?? $params['primarycolor']);
+
+            $this->settingsRepo->saveSetting('companysettings.primarycolor', $primaryColor);
+            $this->settingsRepo->saveSetting('companysettings.secondarycolor', $secondaryColor);
 
             // Check if main color is still in the system
             // if so remove. This call should be removed in a few versions.
@@ -146,8 +149,8 @@ class EditCompanySettings extends Controller
                 $this->settingsRepo->deleteSetting('companysettings.mainColor');
             }
 
-            session(['companysettings.primarycolor' => htmlentities(addslashes($params['primarycolor']))]);
-            session(['companysettings.secondarycolor' => htmlentities(addslashes($params['secondarycolor']))]);
+            session(['companysettings.primarycolor' => $primaryColor]);
+            session(['companysettings.secondarycolor' => $secondaryColor]);
 
             $this->tpl->setNotification($this->language->__('notifications.company_settings_edited_successfully'), 'success');
         }
@@ -205,4 +208,15 @@ class EditCompanySettings extends Controller
      * delete - handle delete requests
      */
     public function delete($params) {}
+
+    private function sanitizeHexColor(string $color): string
+    {
+        $color = trim($color);
+
+        if (preg_match('/^#[0-9a-fA-F]{6}$/', $color) === 1) {
+            return $color;
+        }
+
+        return '#006c9e';
+    }
 }

--- a/app/Domain/Setting/Templates/editCompanySettings.tpl.php
+++ b/app/Domain/Setting/Templates/editCompanySettings.tpl.php
@@ -72,6 +72,28 @@ $companySettings = $tpl->get('companySettings');
                                     </div>
                                     <br />
                                     <h4 class="widgettitle title-light"><span
+                                            class="fa fa-palette"></span><?php echo $tpl->__('tabs.theme'); ?>
+                                    </h4>
+                                    <div class="row">
+                                        <div class="col-md-2">
+                                            <label for="primarycolor"><?= $tpl->__('label.theme_color')?></label>
+                                        </div>
+                                        <div class="col-md-8">
+                                            <div style="display:flex; gap:20px; flex-wrap:wrap; align-items:flex-start;">
+                                                <label style="display:flex; flex-direction:column; gap:6px;">
+                                                    <span><?= $tpl->__('label.primary_color')?></span>
+                                                    <input type="color" name="primarycolor" id="primarycolor" value="<?= $companySettings['primarycolor'] ?: '#006c9e' ?>" style="width:70px; height:42px; padding:2px;" />
+                                                </label>
+                                                <label style="display:flex; flex-direction:column; gap:6px;">
+                                                    <span><?= $tpl->__('label.secondary_color')?></span>
+                                                    <input type="color" name="secondarycolor" id="secondarycolor" value="<?= $companySettings['secondarycolor'] ?: '#19b394' ?>" style="width:70px; height:42px; padding:2px;" />
+                                                </label>
+                                            </div>
+                                            <small><?= $tpl->__('text.update_theme')?></small>
+                                        </div>
+                                    </div>
+                                    <br />
+                                    <h4 class="widgettitle title-light"><span
                                             class="fa fa-cog"></span><?php echo $tpl->__('subtitles.defaults'); ?>
                                     </h4>
                                     <div class="row">

--- a/tests/Unit/app/Core/UI/ThemeTest.php
+++ b/tests/Unit/app/Core/UI/ThemeTest.php
@@ -39,8 +39,12 @@ class ThemeTest extends \Unit\TestCase
             define('BASE_URL', 'http://localhost');
         }
 
-        $this->settingsRepoMock = $this->make(Setting::class, [
+        session()->forget('usersettings.colorScheme');
+        session()->forget('usersettings.colors.primaryColor');
+        session()->forget('usersettings.colors.secondaryColor');
 
+        $this->settingsRepoMock = $this->make(Setting::class, [
+            'getSetting' => false,
         ]);
         $this->languageMock = $this->make(Language::class, [
 
@@ -74,6 +78,9 @@ class ThemeTest extends \Unit\TestCase
      */
     public function test_get_default_color_scheme_with_color_env_set()
     {
+        session()->forget('usersettings.colorScheme');
+        session()->forget('usersettings.colors.primaryColor');
+        session()->forget('usersettings.colors.secondaryColor');
 
         // Load class to be tested
         $this->theme = new Theme(
@@ -94,6 +101,9 @@ class ThemeTest extends \Unit\TestCase
      */
     public function test_get_default_color_scheme_without_env()
     {
+        session()->forget('usersettings.colorScheme');
+        session()->forget('usersettings.colors.primaryColor');
+        session()->forget('usersettings.colors.secondaryColor');
 
         $configMock = $this->make(Environment::class, []);
 
@@ -108,5 +118,36 @@ class ThemeTest extends \Unit\TestCase
         $colorScheme = $theme->getColorScheme();
         $this->assertEquals('themeDefault', $colorScheme);
 
+    }
+
+    public function test_get_default_color_scheme_uses_company_settings_colors()
+    {
+        session()->forget('usersettings.colorScheme');
+        session()->forget('usersettings.colors.primaryColor');
+        session()->forget('usersettings.colors.secondaryColor');
+
+        $settingsRepoMock = $this->make(Setting::class, [
+            'getSetting' => function ($key) {
+                return match ($key) {
+                    'companysettings.primarycolor' => '#112233',
+                    'companysettings.secondarycolor' => '#445566',
+                    default => false,
+                };
+            },
+        ]);
+
+        $configMock = $this->make(Environment::class, []);
+
+        $theme = new Theme(
+            settingsRepo: $settingsRepoMock,
+            language: $this->languageMock,
+            config: $configMock,
+            appSettings: $this->appSettingsMock,
+            fileManager: $this->fileManagerMock
+        );
+
+        $colorScheme = $theme->getColorScheme();
+
+        $this->assertEquals('companyColors', $colorScheme);
     }
 }


### PR DESCRIPTION
## Intent summary
Promote the admin branding controls improvement to `master` so company settings expose the theme branding knobs needed for production support/admin styling.

## User stories / acceptance criteria
- As an admin, I should be able to edit the relevant branding colors from company settings.
- As the theme layer, I should normalize configured branding values consistently so the selected colors render correctly.

## Key files changed
- `app/Core/UI/Theme.php`
- `app/Domain/Setting/Controllers/EditCompanySettings.php`
- `app/Domain/Setting/Templates/editCompanySettings.tpl.php`
- `tests/Unit/app/Core/UI/ThemeTest.php`

## How to test
- `vendor\bin\phpunit.bat tests\Unit\app\Core\UI\ThemeTest.php`

## QA checklist
- Open company settings and confirm the branding controls are present.
- Save updated branding values and confirm they are accepted without malformed quoting.
- Confirm the theme uses the saved values in the expected rendered surfaces.

## Approval conditions
- Merge if the targeted PHPUnit test passes and admin settings QA confirms branding values save and render correctly.
