### PR TITLE
Promote comment spacing parity fix to production

### DIFF
--- a/public/assets/css/components/style.default.css
+++ b/public/assets/css/components/style.default.css
@@ -2171,6 +2171,13 @@ body .widgettitle .editHeadline:hover {
     margin: 0;
 }
 
+.commentContent .tiptap-content p {
+    margin: 0 0 1em 0;
+}
+
+.commentContent .tiptap-content p:last-child {
+    margin-bottom: 0;
+}
 #mainToggler {
     margin-bottom:15px;
     display:block;

--- a/public/assets/js/app/core/tiptap/index.js
+++ b/public/assets/js/app/core/tiptap/index.js
@@ -8,7 +8,7 @@
  */
 
 // Use require for Node/Webpack compatibility
-const { Editor } = require('@tiptap/core');
+const { Editor, Extension } = require('@tiptap/core');
 const StarterKit = require('@tiptap/starter-kit').default;
 const Placeholder = require('@tiptap/extension-placeholder').default;
 const Link = require('@tiptap/extension-link').default;
@@ -194,6 +194,22 @@ var defaultOptions = {
     onFocus: null,
     onCreate: null,
 };
+
+var simpleCommentSpacingExtension = Extension.create({
+    name: 'simpleCommentSpacing',
+
+    addKeyboardShortcuts() {
+        return {
+            Enter: () => this.editor.commands.first(({ commands }) => [
+                () => commands.newlineInCode(),
+                () => commands.createParagraphNear(),
+                () => commands.liftEmptyBlock(),
+                () => commands.splitBlock(),
+            ]),
+            'Shift-Enter': () => this.editor.commands.setHardBreak(),
+        };
+    },
+});
 
 /**
  * Create a Tiptap editor instance
@@ -391,6 +407,10 @@ function createTiptapEditor(elementOrSelector, options) {
             TableCell,
             TableHeader
         );
+    }
+
+    if (options.toolbar === 'simple') {
+        extensions.push(simpleCommentSpacingExtension);
     }
 
     // Create editor

--- a/tests/Unit/app/Domain/Comments/CommentSpacingSourceTest.php
+++ b/tests/Unit/app/Domain/Comments/CommentSpacingSourceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit\app\Domain\Comments;
+
+use Unit\TestCase;
+
+class CommentSpacingSourceTest extends TestCase
+{
+    private function repoPath(string $relativePath): string
+    {
+        return realpath(__DIR__.'/../../../../../'.$relativePath) ?: __DIR__.'/../../../../../'.$relativePath;
+    }
+
+    public function test_simple_tiptap_editor_has_explicit_enter_and_shift_enter_shortcuts(): void
+    {
+        $source = file_get_contents($this->repoPath('public/assets/js/app/core/tiptap/index.js'));
+
+        $this->assertIsString($source);
+        $this->assertStringContainsString("name: 'simpleCommentSpacing'", $source);
+        $this->assertStringContainsString("Enter: () => this.editor.commands.first", $source);
+        $this->assertStringContainsString("'Shift-Enter': () => this.editor.commands.setHardBreak()", $source);
+        $this->assertStringContainsString("if (options.toolbar === 'simple')", $source);
+    }
+
+    public function test_rendered_comment_content_keeps_paragraph_spacing(): void
+    {
+        $source = file_get_contents($this->repoPath('public/assets/css/components/style.default.css'));
+
+        $this->assertIsString($source);
+        $this->assertStringContainsString('.commentContent .tiptap-content p {', $source);
+        $this->assertStringContainsString('.commentContent .tiptap-content p:last-child {', $source);
+    }
+}


### PR DESCRIPTION
## Intent summary
Promote the comment spacing parity fix to `master` so rendered comment content uses the same spacing rules across Tiptap and display contexts.

## User stories / acceptance criteria
- As a user viewing formatted comments, I should see consistent paragraph spacing instead of collapsed or uneven spacing.
- As a maintainer, I should have a source-level regression test that guards the spacing rules and Tiptap registration.

## Key files changed
- `public/assets/css/components/style.default.css`
- `public/assets/js/app/core/tiptap/index.js`
- `tests/Unit/app/Domain/Comments/CommentSpacingSourceTest.php`

## How to test
- `vendor\bin\phpunit.bat tests\Unit\app\Domain\Comments\CommentSpacingSourceTest.php`

## QA checklist
- Add a multi-paragraph comment and confirm paragraph spacing is preserved when rendered.
- Confirm existing comments still render normally in the ticket/task views that use Tiptap output.

## Approval conditions
- Merge if the targeted PHPUnit test passes and visual QA confirms spacing parity on production-relevant comment surfaces.
